### PR TITLE
Adding variable support

### DIFF
--- a/octopusdeploy/data_variable.go
+++ b/octopusdeploy/data_variable.go
@@ -1,0 +1,121 @@
+package octopusdeploy
+
+import (
+	"fmt"
+
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataVariable() *schema.Resource {
+	return &schema.Resource{
+		Read: dataVariableReadByName,
+		Schema: map[string]*schema.Schema{
+			"project_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"value": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"scope": schemaVariableScope,
+		},
+	}
+}
+
+var schemaVariableScopeValue = &schema.Schema{
+	Type: schema.TypeList,
+	Elem: &schema.Schema{
+		Type: schema.TypeString,
+	},
+	Optional: true,
+}
+
+var schemaVariableScope = &schema.Schema{
+	Type:     schema.TypeSet,
+	MaxItems: 1,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"environments": schemaVariableScopeValue,
+			"machines":     schemaVariableScopeValue,
+			"actions":      schemaVariableScopeValue,
+			"roles":        schemaVariableScopeValue,
+			"channels":     schemaVariableScopeValue,
+			"tenant_tags":  schemaVariableScopeValue,
+		},
+	},
+}
+
+// tfVariableScopetoODVariableScope converts a Terraform ResourceData into an OctopusDeploy VariableScope
+func tfVariableScopetoODVariableScope(d *schema.ResourceData) *octopusdeploy.VariableScope {
+	//Get the schema set. We specify a MaxItems of 1, so we will only ever have zero or one items
+	//in our list.
+	tfSchemaSetInterface, ok := d.GetOk("scope")
+	if !ok {
+		return nil
+	}
+
+	tfSchemaSet := tfSchemaSetInterface.(*schema.Set)
+	if len(tfSchemaSet.List()) == 0 {
+		return nil
+	}
+
+	//Get the first element in the list, which is a map of the interfaces
+	tfSchemaList := tfSchemaSet.List()[0].(map[string]interface{})
+
+	//Use the getSliceFromTerraformTypeList helper to convert the data from the map into []string and
+	//assign as the variable scopes we need
+	var newScope octopusdeploy.VariableScope
+	newScope.Environment = getSliceFromTerraformTypeList(tfSchemaList["environments"])
+	newScope.Action = getSliceFromTerraformTypeList(tfSchemaList["actions"])
+	newScope.Role = getSliceFromTerraformTypeList(tfSchemaList["roles"])
+	newScope.Channel = getSliceFromTerraformTypeList(tfSchemaList["channels"])
+	newScope.Machine = getSliceFromTerraformTypeList(tfSchemaList["machines"])
+	newScope.TenantTag = getSliceFromTerraformTypeList(tfSchemaList["tenant_tags"])
+
+	return &newScope
+}
+
+func dataVariableReadByName(d *schema.ResourceData, m interface{}) error {
+	client := m.(*octopusdeploy.Client)
+
+	varProject := d.Get("project_id")
+	varName := d.Get("name")
+	varScope := tfVariableScopetoODVariableScope(d)
+
+	varItems, err := client.Variable.GetByName(varProject.(string), varName.(string), varScope)
+
+	if err == octopusdeploy.ErrItemNotFound {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading variable from project %s with name %s: %s", varProject, varName, err.Error())
+	}
+
+	if len(varItems) > 1 {
+		return fmt.Errorf("found %v variables for project %s with name %s, should match exactly 1", len(varItems), varProject, varName)
+	}
+
+	d.SetId(varItems[0].ID)
+	d.Set("name", varItems[0].Name)
+	d.Set("type", varItems[0].Type)
+	d.Set("value", varItems[0].Value)
+	d.Set("description", varItems[0].Description)
+
+	return nil
+}

--- a/octopusdeploy/provider.go
+++ b/octopusdeploy/provider.go
@@ -13,12 +13,14 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"octopusdeploy_project":     dataProject(),
 			"octopusdeploy_environment": dataEnvironment(),
+			"octopusdeploy_variable":    dataVariable(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"octopusdeploy_project":                           resourceProject(),
 			"octopusdeploy_project_group":                     resourceProjectGroup(),
 			"octopusdeploy_project_deployment_target_trigger": resourceProjectDeploymentTargetTrigger(),
 			"octopusdeploy_environment":                       resourceEnvironment(),
+			"octopusdeploy_variable":                          resourceVariable(),
 		},
 		Schema: map[string]*schema.Schema{
 			"address": &schema.Schema{

--- a/octopusdeploy/resource_variable.go
+++ b/octopusdeploy/resource_variable.go
@@ -34,9 +34,8 @@ func resourceVariable() *schema.Resource {
 				}),
 			},
 			"value": &schema.Schema{
-				Type:      schema.TypeString,
-				Required:  true,
-				Sensitive: true,
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,

--- a/octopusdeploy/resource_variable.go
+++ b/octopusdeploy/resource_variable.go
@@ -78,9 +78,6 @@ func resourceVariable() *schema.Resource {
 }
 
 func resourceVariableRead(d *schema.ResourceData, m interface{}) error {
-	octoMutex.Lock("atom-variable")
-	defer octoMutex.Unlock("atom-variable")
-
 	client := m.(*octopusdeploy.Client)
 
 	variableID := d.Id()

--- a/octopusdeploy/resource_variable.go
+++ b/octopusdeploy/resource_variable.go
@@ -244,3 +244,5 @@ func validateVariable(d *schema.ResourceData) error {
 
 	return nil
 }
+
+//Noop to get GitHub to re-run unit tests

--- a/octopusdeploy/resource_variable.go
+++ b/octopusdeploy/resource_variable.go
@@ -1,0 +1,184 @@
+package octopusdeploy
+
+import (
+	"fmt"
+
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceVariable() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVariableCreate,
+		Read:   resourceVariableRead,
+		Update: resourceVariableUpdate,
+		Delete: resourceVariableDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validateValueFunc([]string{
+					"String",
+					"Sensitive",
+					"Certificate",
+					"AmazonWebServicesAccount",
+				}),
+			},
+			"value": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"scope": schemaVariableScope,
+			"is_sensitive": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceVariableRead(d *schema.ResourceData, m interface{}) error {
+	octoMutex.Lock("atom-variable")
+	defer octoMutex.Unlock("atom-variable")
+
+	client := m.(*octopusdeploy.Client)
+
+	variableID := d.Id()
+	projectID := d.Get("project_id").(string)
+	tfVar, err := client.Variable.GetByID(projectID, variableID)
+
+	if err == octopusdeploy.ErrItemNotFound || tfVar == nil {
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Variable %s: %s", variableID, err.Error())
+	}
+
+	d.Set("name", tfVar.Name)
+	d.Set("type", tfVar.Type)
+	d.Set("value", tfVar.Value)
+	d.Set("description", tfVar.Description)
+
+	return nil
+}
+
+func buildVariableResource(d *schema.ResourceData) *octopusdeploy.Variable {
+	varName := d.Get("name").(string)
+	varType := d.Get("type").(string)
+	varValue := d.Get("value").(string)
+
+	var varDesc string
+	var varSensitive bool
+
+	varDescInterface, ok := d.GetOk("description")
+	if ok {
+		varDesc = varDescInterface.(string)
+	}
+
+	varSensitiveInterface, ok := d.GetOk("is_sensitive")
+	if ok {
+		varSensitive = varSensitiveInterface.(bool)
+	}
+
+	varScopeInterface := tfVariableScopetoODVariableScope(d)
+
+	newVar := octopusdeploy.NewVariable(varName, varType, varValue, varDesc, varScopeInterface, varSensitive)
+	newVar.Prompt.Required = false
+
+	return newVar
+}
+
+func resourceVariableCreate(d *schema.ResourceData, m interface{}) error {
+	octoMutex.Lock("atom-variable")
+	defer octoMutex.Unlock("atom-variable")
+
+	client := m.(*octopusdeploy.Client)
+	projID := d.Get("project_id").(string)
+
+	newVariable := buildVariableResource(d)
+	tfVar, err := client.Variable.AddSingle(projID, newVariable)
+
+	if err != nil {
+		return fmt.Errorf("error creating variable %s: %s", newVariable.Name, err.Error())
+	}
+
+	for _, v := range tfVar.Variables {
+		if v.Name == newVariable.Name && v.Type == newVariable.Type && v.Value == newVariable.Value && v.Description == newVariable.Description && v.IsSensitive == newVariable.IsSensitive {
+			scopeMatches, _, err := client.Variable.MatchesScope(v.Scope, newVariable.Scope)
+			if err != nil {
+				return err
+			}
+			if scopeMatches {
+				d.SetId(v.ID)
+				return nil
+			}
+		}
+	}
+
+	d.SetId("")
+	return fmt.Errorf("unable to locate variable in project %s", projID)
+}
+
+func resourceVariableUpdate(d *schema.ResourceData, m interface{}) error {
+	octoMutex.Lock("atom-variable")
+	defer octoMutex.Unlock("atom-variable")
+
+	tfVar := buildVariableResource(d)
+	tfVar.ID = d.Id() // set project struct ID so octopus knows which project to update
+
+	client := m.(*octopusdeploy.Client)
+	projID := d.Get("project_id").(string)
+
+	updatedVars, err := client.Variable.UpdateSingle(projID, tfVar)
+
+	if err != nil {
+		return fmt.Errorf("error updating variable id %s: %s", d.Id(), err.Error())
+	}
+
+	for _, v := range updatedVars.Variables {
+		if v.Name == tfVar.Name && v.Type == tfVar.Type && v.Value == tfVar.Value && v.Description == tfVar.Description && v.IsSensitive == tfVar.IsSensitive {
+			scopeMatches, _, _ := client.Variable.MatchesScope(v.Scope, tfVar.Scope)
+			if scopeMatches {
+				d.SetId(v.ID)
+				return nil
+			}
+		}
+	}
+
+	d.SetId("")
+	return fmt.Errorf("unable to locate variable in project %s", projID)
+}
+
+func resourceVariableDelete(d *schema.ResourceData, m interface{}) error {
+	octoMutex.Lock("atom-variable")
+	defer octoMutex.Unlock("atom-variable")
+
+	client := m.(*octopusdeploy.Client)
+	projID := d.Get("project_id").(string)
+
+	variableID := d.Id()
+
+	_, err := client.Variable.DeleteSingle(projID, variableID)
+
+	if err != nil {
+		return fmt.Errorf("error deleting variable id %s: %s", variableID, err.Error())
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/octopusdeploy/resource_variable_test.go
+++ b/octopusdeploy/resource_variable_test.go
@@ -1,0 +1,85 @@
+package octopusdeploy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOctopusDeployVariableBasic(t *testing.T) {
+	const tfVarPrefix = "octopusdeploy_variable.foo"
+	const tfVarProjectID = "Projects-1"
+	const tfVarName = "tf-var-1"
+	const tfVarDesc = "Terraform testing module variable"
+	const tfVarValue = "abcd-123456"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testOctopusDeployVariableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testVariableBasic(tfVarProjectID, tfVarName, tfVarDesc, tfVarValue),
+				Check: resource.ComposeTestCheckFunc(
+					testOctopusDeployVariableExists(tfVarPrefix),
+					resource.TestCheckResourceAttr(
+						tfVarPrefix, "name", tfVarName),
+					resource.TestCheckResourceAttr(
+						tfVarPrefix, "description", tfVarDesc),
+					resource.TestCheckResourceAttr(
+						tfVarPrefix, "value", tfVarValue),
+				),
+			},
+		},
+	})
+}
+
+func testVariableBasic(projectID, name, description, value string) string {
+	return fmt.Sprintf(`
+		resource "octopusdeploy_variable" "foo" {
+			project_id  = "%s"
+			name        = "%s"
+			description = "%s"
+			type        = "String"
+			value       = "%s"
+		}
+		`,
+		projectID, name, description, value,
+	)
+}
+
+func testOctopusDeployVariableExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*octopusdeploy.Client)
+		return existsVarHelper(s, client)
+	}
+}
+
+func existsVarHelper(s *terraform.State, client *octopusdeploy.Client) error {
+	for _, r := range s.RootModule().Resources {
+		if _, err := client.Variable.GetByID(r.Primary.Attributes["project_id"], r.Primary.ID); err != nil {
+			return fmt.Errorf("Received an error retrieving variable %s", err)
+		}
+	}
+	return nil
+}
+
+func testOctopusDeployVariableDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*octopusdeploy.Client)
+	return destroyVarHelper(s, client)
+}
+
+func destroyVarHelper(s *terraform.State, client *octopusdeploy.Client) error {
+	for _, r := range s.RootModule().Resources {
+		if _, err := client.Variable.DeleteSingle(r.Primary.Attributes["project_id"], r.Primary.ID); err != nil {
+			if err == octopusdeploy.ErrItemNotFound {
+				continue
+			}
+			return fmt.Errorf("Received an error retrieving variable %s", err)
+		}
+		return fmt.Errorf("Variable still exists")
+	}
+	return nil
+}

--- a/octopusdeploy/util.go
+++ b/octopusdeploy/util.go
@@ -3,8 +3,13 @@ package octopusdeploy
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 )
+
+// Octopus can get itself into some race conditions, so this mutex can be used to ensure
+// that we wait for other commands to finish first.
+var octoMutex = mutexkv.NewMutexKV()
 
 // Validate a value against a set of possible values
 func validateValueFunc(values []string) schema.SchemaValidateFunc {

--- a/vendor/github.com/MattHodge/go-octopusdeploy/octopusdeploy/octopusdeploy.go
+++ b/vendor/github.com/MattHodge/go-octopusdeploy/octopusdeploy/octopusdeploy.go
@@ -18,6 +18,7 @@ type Client struct {
 	Project           *ProjectService
 	ProjectTrigger    *ProjectTriggerService
 	Environment       *EnvironmentService
+	Variable          *VariableService
 }
 
 // NewClient returns a new Client.
@@ -33,6 +34,7 @@ func NewClient(httpClient *http.Client, octopusURL, octopusAPIKey string) *Clien
 		Project:           NewProjectService(base.New()),
 		ProjectTrigger:    NewProjectTriggerService(base.New()),
 		Environment:       NewEnvironmentService(base.New()),
+		Variable:          NewVariableService(base.New()),
 	}
 }
 
@@ -111,7 +113,6 @@ func apiAdd(sling *sling.Sling, inputStruct, returnStruct interface{}, path stri
 // Generic OctopusDeploy API Add Function.
 func apiUpdate(sling *sling.Sling, inputStruct, returnStruct interface{}, path string) (interface{}, error) {
 	octopusDeployError := new(APIError)
-
 	resp, err := sling.New().Put(path).BodyJSON(inputStruct).Receive(returnStruct, &octopusDeployError)
 
 	apiErrorCheck := APIErrorChecker(path, resp, http.StatusOK, err, octopusDeployError)

--- a/vendor/github.com/MattHodge/go-octopusdeploy/octopusdeploy/variables.go
+++ b/vendor/github.com/MattHodge/go-octopusdeploy/octopusdeploy/variables.go
@@ -27,15 +27,15 @@ type Variables struct {
 }
 
 type Variable struct {
-	ID          string                `json:"Id"`
-	Name        string                `json:"Name"`
-	Value       string                `json:"Value"`
-	Description string                `json:"Description"`
-	Scope       *VariableScope        `json:"Scope,omitempty"`
-	IsEditable  bool                  `json:"IsEditable"`
-	Prompt      VariablePromptOptions `json:"Prompt"`
-	Type        string                `json:"Type"`
-	IsSensitive bool                  `json:"IsSensitive"`
+	ID          string                 `json:"Id"`
+	Name        string                 `json:"Name"`
+	Value       string                 `json:"Value"`
+	Description string                 `json:"Description"`
+	Scope       *VariableScope         `json:"Scope,omitempty"`
+	IsEditable  bool                   `json:"IsEditable"`
+	Prompt      *VariablePromptOptions `json:"Prompt"`
+	Type        string                 `json:"Type"`
+	IsSensitive bool                   `json:"IsSensitive"`
 }
 
 type VariableScope struct {

--- a/vendor/github.com/MattHodge/go-octopusdeploy/octopusdeploy/variables.go
+++ b/vendor/github.com/MattHodge/go-octopusdeploy/octopusdeploy/variables.go
@@ -181,7 +181,7 @@ func (s *VariableService) UpdateSingle(projectid string, variable *Variable) (*V
 	}
 
 	if !found {
-		return nil, fmt.Errorf("Variable with ID %s was not found in variable set %s for updating", variable.ID, projectid)
+		return nil, ErrItemNotFound
 	}
 
 	return s.Update(projectid, variables)
@@ -204,7 +204,7 @@ func (s *VariableService) DeleteSingle(projectid string, variableID string) (*Va
 	}
 
 	if !found {
-		return nil, fmt.Errorf("Variable with ID %s was not found in variable set %s for removal", variableID, projectid)
+		return nil, ErrItemNotFound
 	}
 
 	return s.Update(projectid, variables)

--- a/vendor/github.com/MattHodge/go-octopusdeploy/octopusdeploy/variables.go
+++ b/vendor/github.com/MattHodge/go-octopusdeploy/octopusdeploy/variables.go
@@ -1,0 +1,310 @@
+package octopusdeploy
+
+import (
+	"fmt"
+
+	"github.com/dghubble/sling"
+	"gopkg.in/go-playground/validator.v9"
+)
+
+type VariableService struct {
+	sling *sling.Sling
+}
+
+func NewVariableService(sling *sling.Sling) *VariableService {
+	return &VariableService{
+		sling: sling,
+	}
+}
+
+type Variables struct {
+	ID          string      `json:"Id"`
+	OwnerID     string      `json:"OwnerId"`
+	Version     int         `json:"Version"`
+	Variables   []Variable  `json:"Variables"`
+	ScopeValues ScopeValues `json:"ScopeValues"`
+	Links       map[string]string
+}
+
+type Variable struct {
+	ID          string                `json:"Id"`
+	Name        string                `json:"Name"`
+	Value       string                `json:"Value"`
+	Description string                `json:"Description"`
+	Scope       *VariableScope        `json:"Scope,omitempty"`
+	IsEditable  bool                  `json:"IsEditable"`
+	Prompt      VariablePromptOptions `json:"Prompt"`
+	Type        string                `json:"Type"`
+	IsSensitive bool                  `json:"IsSensitive"`
+}
+
+type VariableScope struct {
+	Project     []string `json:"Project,omitempty"`
+	Environment []string `json:"Environment,omitempty"`
+	Machine     []string `json:"Machine,omitempty"`
+	Role        []string `json:"Role,omitempty"`
+	TargetRole  []string `json:"TargetRole,omitempty"`
+	Action      []string `json:"Action,omitempty"`
+	User        []string `json:"User,omitempty"`
+	Private     []string `json:"Private,omitempty"`
+	Channel     []string `json:"Channel,omitempty"`
+	TenantTag   []string `json:"TenantTag,omitempty"`
+	Tenant      []string `json:"Tenant,omitempty"`
+}
+
+type VariablePromptOptions struct {
+	Label       string `json:"Label"`
+	Description string `json:"Description"`
+	Required    bool   `json:"Required"`
+}
+
+type ScopeValues struct {
+	Environments []ScopeValue `json:"Environments"`
+	Machines     []ScopeValue `json:"Machines"`
+	Actions      []ScopeValue `json:"Actions"`
+	Roles        []ScopeValue `json:"Roles"`
+	Channels     []ScopeValue `json:"Channels"`
+	TenantTags   []ScopeValue `json:"TenantTags"`
+}
+
+type ScopeValue struct {
+	ID   string `json:"Id"`
+	Name string `json:"Name"`
+}
+
+func (t *Variable) Validate() error {
+	validate := validator.New()
+
+	err := validate.Struct(t)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func NewVariable(name, valuetype, value, description string, scope *VariableScope, sensitive bool) *Variable {
+	return &Variable{
+		Name:        name,
+		Value:       value,
+		Description: description,
+		Type:        valuetype,
+		IsSensitive: sensitive,
+		Scope:       scope,
+	}
+}
+
+// GetAll fetches an entire VariableSet from Octopus Deploy for a given Project ID.
+func (s *VariableService) GetAll(projectid string) (*Variables, error) {
+	if projectid == "" { //Not specifying the Project ID can return thousands of entries consuming hundreds of megs of memory
+		return nil, fmt.Errorf("projectid must be specified")
+	}
+
+	path := fmt.Sprintf("variables/variableset-%s", projectid)
+	resp, err := apiGet(s.sling, new(Variables), path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*Variables), nil
+}
+
+// GetByID fetches a single variable, located by its ID, from Octopus Deploy for a given Project ID.
+func (s *VariableService) GetByID(projectid, variableid string) (*Variable, error) {
+	variables, err := s.GetAll(projectid)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, variable := range variables.Variables {
+		if variable.ID == variableid {
+			return &variable, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// GetByName fetches variables, located by their name, from Octopus Deploy for a given Project ID. As variable
+// names can appear more than once under different scopes, a VariableScope must also be provided, which will
+// be used to locate the appropriate variables.
+func (s *VariableService) GetByName(projectid, variablename string, scope *VariableScope) ([]Variable, error) {
+	variables, err := s.GetAll(projectid)
+	if err != nil {
+		return nil, err
+	}
+
+	var matchedVariables []Variable
+
+	for _, variable := range variables.Variables {
+		if variable.Name == variablename {
+			matchScope, _, err := s.MatchesScope(variable.Scope, scope)
+			if err != nil {
+				return nil, err
+			}
+			if matchScope {
+				matchedVariables = append(matchedVariables, variable)
+			}
+		}
+	}
+
+	return matchedVariables, nil
+}
+
+// AddSingle adds a single variable to a project ID. This automates the act of fetching
+// the variable set, adding a new item to it, and posting back to Octopus
+func (s *VariableService) AddSingle(projectid string, variable *Variable) (*Variables, error) {
+	variables, err := s.GetAll(projectid)
+	if err != nil {
+		return nil, err
+	}
+	variables.Variables = append(variables.Variables, *variable)
+	return s.Update(projectid, variables)
+}
+
+// UpdateSingle adds a single variable to a project ID. This automates the act of fetching
+// the variable set, updating the existing item, and posting back to Octopus
+func (s *VariableService) UpdateSingle(projectid string, variable *Variable) (*Variables, error) {
+	variables, err := s.GetAll(projectid)
+	if err != nil {
+		return nil, err
+	}
+
+	var found bool
+	for i, existingVar := range variables.Variables {
+		if existingVar.ID == variable.ID {
+			variables.Variables[i] = *variable
+			found = true
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("Variable with ID %s was not found in variable set %s for updating", variable.ID, projectid)
+	}
+
+	return s.Update(projectid, variables)
+}
+
+// DeleteSingle removes a single variable from a project ID. This automates the act of fetching
+// the variable set, removing the existing item, and posting back to Octopus
+func (s *VariableService) DeleteSingle(projectid string, variableID string) (*Variables, error) {
+	variables, err := s.GetAll(projectid)
+	if err != nil {
+		return nil, err
+	}
+
+	var found bool
+	for i, existingVar := range variables.Variables {
+		if existingVar.ID == variableID {
+			variables.Variables = append(variables.Variables[:i], variables.Variables[i+1:]...)
+			found = true
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("Variable with ID %s was not found in variable set %s for removal", variableID, projectid)
+	}
+
+	return s.Update(projectid, variables)
+}
+
+// Update takes an entire variable set and posts the entire set back to Octopus Deploy. There are individual
+// functions like AddSingle and UpdateSingle that can make this process more of a "typical" CRUD Octopus command.
+func (s *VariableService) Update(projectid string, variableSet *Variables) (*Variables, error) {
+	path := fmt.Sprintf("variables/variableset-%s", projectid)
+	resp, err := apiUpdate(s.sling, variableSet, new(Variables), path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*Variables), nil
+}
+
+// MatchesScope compares two different scopes to see if they match. Generally used for comparing the scope of
+// an existing variable against a desired state. Only supports Environment, Role, Machine, Action and Channel
+// for scope options. Returns true if definedScope is nil or all elements are empty. Also returns a VariableScope
+// of all the scopes that were matched
+func (s *VariableService) MatchesScope(variableScope, definedScope *VariableScope) (bool, *VariableScope, error) {
+	var matchedScopes VariableScope
+	var matched bool
+
+	//If the scope supplied is nil then match everything
+	if definedScope == nil {
+		return true, &matchedScopes, nil
+	}
+
+	//Unsupported scopes
+	if len(definedScope.Private) > 0 {
+		return false, nil, fmt.Errorf("Private is not a supported scope for variable matching")
+	}
+	if len(definedScope.Project) > 0 {
+		return false, nil, fmt.Errorf("Project is not a supported scope for variable matching")
+	}
+	if len(definedScope.TargetRole) > 0 {
+		return false, nil, fmt.Errorf("TargetRole is not a supported scope for variable matching")
+	}
+	if len(definedScope.Tenant) > 0 {
+		return false, nil, fmt.Errorf("Tenant is not a supported scope for variable matching")
+	}
+	if len(definedScope.TenantTag) > 0 {
+		return false, nil, fmt.Errorf("TenantTag is not a supported scope for variable matching")
+	}
+	if len(definedScope.User) > 0 {
+		return false, nil, fmt.Errorf("User is not a supported scope for variable matching")
+	}
+
+	//If there is no scope to filter on return all the results
+	if len(definedScope.Environment) > 0 && len(definedScope.Role) > 0 && len(definedScope.Machine) > 0 && len(definedScope.Action) > 0 && len(definedScope.Channel) > 0 {
+		return true, &matchedScopes, nil
+	}
+
+	for _, e1 := range definedScope.Environment {
+		for _, e2 := range variableScope.Environment {
+			if e1 == e2 {
+				matched = true
+				matchedScopes.Environment = append(matchedScopes.Environment, e1)
+			}
+		}
+	}
+
+	for _, r1 := range definedScope.Role {
+		for _, r2 := range variableScope.Role {
+			if r1 == r2 {
+				matched = true
+				matchedScopes.Role = append(matchedScopes.Role, r1)
+			}
+		}
+	}
+
+	for _, m1 := range definedScope.Machine {
+		for _, m2 := range variableScope.Machine {
+			if m1 == m2 {
+				matched = true
+				matchedScopes.Machine = append(matchedScopes.Machine, m1)
+			}
+		}
+	}
+
+	for _, a1 := range definedScope.Action {
+		for _, a2 := range variableScope.Action {
+			if a1 == a2 {
+				matched = true
+				matchedScopes.Action = append(matchedScopes.Action, a1)
+			}
+		}
+	}
+
+	for _, c1 := range definedScope.Channel {
+		for _, c2 := range variableScope.Channel {
+			if c1 == c2 {
+				matched = true
+				matchedScopes.Channel = append(matchedScopes.Channel, c1)
+			}
+		}
+	}
+
+	return matched, &matchedScopes, nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/mutexkv/mutexkv.go
+++ b/vendor/github.com/hashicorp/terraform/helper/mutexkv/mutexkv.go
@@ -1,0 +1,51 @@
+package mutexkv
+
+import (
+	"log"
+	"sync"
+)
+
+// MutexKV is a simple key/value store for arbitrary mutexes. It can be used to
+// serialize changes across arbitrary collaborators that share knowledge of the
+// keys they must serialize on.
+//
+// The initial use case is to let aws_security_group_rule resources serialize
+// their access to individual security groups based on SG ID.
+type MutexKV struct {
+	lock  sync.Mutex
+	store map[string]*sync.Mutex
+}
+
+// Locks the mutex for the given key. Caller is responsible for calling Unlock
+// for the same key
+func (m *MutexKV) Lock(key string) {
+	log.Printf("[DEBUG] Locking %q", key)
+	m.get(key).Lock()
+	log.Printf("[DEBUG] Locked %q", key)
+}
+
+// Unlock the mutex for the given key. Caller must have called Lock for the same key first
+func (m *MutexKV) Unlock(key string) {
+	log.Printf("[DEBUG] Unlocking %q", key)
+	m.get(key).Unlock()
+	log.Printf("[DEBUG] Unlocked %q", key)
+}
+
+// Returns a mutex for the given key, no guarantee of its lock status
+func (m *MutexKV) get(key string) *sync.Mutex {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	mutex, ok := m.store[key]
+	if !ok {
+		mutex = &sync.Mutex{}
+		m.store[key] = mutex
+	}
+	return mutex
+}
+
+// Returns a properly initalized MutexKV
+func NewMutexKV() *MutexKV {
+	return &MutexKV{
+		store: make(map[string]*sync.Mutex),
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/mutexkv/mutexkv_test.go
+++ b/vendor/github.com/hashicorp/terraform/helper/mutexkv/mutexkv_test.go
@@ -1,0 +1,67 @@
+package mutexkv
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMutexKVLock(t *testing.T) {
+	mkv := NewMutexKV()
+
+	mkv.Lock("foo")
+
+	doneCh := make(chan struct{})
+
+	go func() {
+		mkv.Lock("foo")
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+		t.Fatal("Second lock was able to be taken. This shouldn't happen.")
+	case <-time.After(50 * time.Millisecond):
+		// pass
+	}
+}
+
+func TestMutexKVUnlock(t *testing.T) {
+	mkv := NewMutexKV()
+
+	mkv.Lock("foo")
+	mkv.Unlock("foo")
+
+	doneCh := make(chan struct{})
+
+	go func() {
+		mkv.Lock("foo")
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+		// pass
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("Second lock blocked after unlock. This shouldn't happen.")
+	}
+}
+
+func TestMutexKVDifferentKeys(t *testing.T) {
+	mkv := NewMutexKV()
+
+	mkv.Lock("foo")
+
+	doneCh := make(chan struct{})
+
+	go func() {
+		mkv.Lock("bar")
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+		// pass
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("Second lock on a different key blocked. This shouldn't happen.")
+	}
+}


### PR DESCRIPTION
This PR adds support for Terraform variables. Variables must be assigned against a project.

All Variable scopes and functions are supported except for sensitive variables. [See this UserVoice request](https://octopusdeploy.uservoice.com/forums/170787-general/suggestions/35616472) to see why. However a bunch of the code for supporting sensitive variables is still in place, but never activated due to `ValidateFunc` on the `is_sensitive` schema.

This PR also includes a preemptive bugfix for the [upstream go-octopusdeploy](https://github.com/MattHodge/go-octopusdeploy/pull/27) module. 