### PR TITLE
Refactor Environment Resource / Data Source + Move Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Based on the [go-octopusdeploy](https://github.com/MattHodge/go-octopusdeploy) O
 - [Go Dependencies](#go-dependencies)
 - [Downloading & Installing](#downloading--installing)
 - [Configure the Provider](#configure-the-provider)
+- [Data Sources](#data-sources)
 - [Provider Resources](#provider-resources)
+- [Provider Resources (To Be Moved To /docs)](#provider-resources-to-be-moved-to-docs)
     - [Project Groups](#project-groups)
         - [Example Usage](#example-usage)
         - [Argument Reference](#argument-reference)
@@ -27,20 +29,16 @@ Based on the [go-octopusdeploy](https://github.com/MattHodge/go-octopusdeploy) O
                 - [Feed and Packages](#feed-and-packages)
                 - [IIS Application Pool](#iis-application-pool)
         - [Attributes Reference](#attributes-reference-1)
-    - [Environment](#environment)
+    - [Variables](#variables)
         - [Example Usage](#example-usage-2)
         - [Argument Reference](#argument-reference-2)
         - [Attributes reference](#attributes-reference)
-    - [Variables](#variables)
+    - [Machine Policies](#machine-policies)
         - [Example Usage](#example-usage-3)
         - [Argument Reference](#argument-reference-3)
-        - [Attributes reference](#attributes-reference-1)
-    - [Machine Policies](#machine-policies)
-        - [Example Usage](#example-usage-4)
-        - [Argument Reference](#argument-reference-4)
         - [Attributes Reference](#attributes-reference-2)
     - [Machines (Deployment Targets)](#machines-deployment-targets)
-        - [Example Usage](#example-usage-5)
+        - [Example Usage](#example-usage-4)
         - [Resource Argument Reference](#resource-argument-reference)
         - [Resource Attribute Reference](#resource-attribute-reference)
         - [Data Argument Reference](#data-argument-reference)
@@ -75,7 +73,16 @@ provider "octopusdeploy" {
 }
 ```
 
+# Data Sources
+
+* [octopusdeploy_environment](docs/provider/data_sources/environment.md)
+
 # Provider Resources
+
+* [octopusdeploy_environment](docs/provider/resources/environment.md)
+
+
+# Provider Resources (To Be Moved To /docs)
 ## Project Groups
 
 [Project groups](https://octopus.com/docs/deployment-process/projects#project-group) are a way of organizing your projects.
@@ -280,43 +287,6 @@ The following arguments are shared amongst the `deployment_step` resources.
 
 ### Attributes Reference
 * `deployment_process_id` - The ID of the projects deployment process.
-
-## Environment
-
-[Environments](https://octopus.com/docs/infrastructure/environments) are a way of defining different configurations for Octopus Deploy.
-
-### Example Usage
-
-Basic usage:
-
-```hcl
-resource "octopusdeploy_environment" "staging" {
-    name = "Staging"
-    description = "Staging environment"
-    useguidedfailure = false
-}
-```
-
-Data usage:
-
-```hcl
-data "octopusdeploy_environment" "staging" {
-    name = "Staging"
-}
-```
-
-### Argument Reference
-
-* `name` - (Required) Name of the environment
-* `description` - (Optional) Description of the environment
-* `useguidedfailure` - (Optional) Use guided failures for this environment (defaults to `false`)
-
-### Attributes reference
-
-* `id` - ID of the environment
-* `name` - Name of the environment
-* `description` - Description of the environment
-* `useguidedfailure` - Use guided failures for this environment
 
 ## Variables
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,4 +1,11 @@
-Decisions
----
+# Decisions
+
+## Development
 
 * You cannot use `ConflictsWith` inside `schema.TypeList`. Instead I am splitting them up into their own `schema.TypeList`.
+
+## Documentation
+
+* Documentation for usage of the Terraform provider will go into the `/docs/provider/` folder and be split into the `data_sources` or `resources` sub-folder.
+
+* Documentation will be done in Markdown and match the style of the official Terraform providers. This is to make it easy to transition to official provider documentation if this occurs.

--- a/docs/provider/data_sources/environment.md
+++ b/docs/provider/data_sources/environment.md
@@ -1,0 +1,23 @@
+# octopusdeploy_environment
+
+Use this data source to retrieve information about an Octopus Deploy [environment](https://octopus.com/docs/infrastructure/environments).
+
+## Example Usage
+
+```hcl
+data "octopusdeploy_environment" "testing" {
+  name = "Testing"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the environment.
+
+## Attributes Reference
+
+* `description` - A description of the environment.
+
+* `use_guided_failure` - Whether guided failure mode is enabled or not.

--- a/docs/provider/resources/environment.md
+++ b/docs/provider/resources/environment.md
@@ -1,0 +1,31 @@
+# octopusdeploy_environment
+
+Use this resource allows the creation of Octopus Deploy [environment](https://octopus.com/docs/infrastructure/environments).
+
+Environments help you organize your deployment targets.
+
+## Example Usage
+
+```hcl
+resource "octopusdeploy_environment" "staging" {
+    name               = "Staging"
+    description        = "Staging environment"
+    use_guided_failure = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the environment.
+
+* `description` - (Optional) Description of the environment.
+
+* `use_guided_failure` - (Optional) Use guided failures for this environment. Defaults to `false`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - ID of the environment.

--- a/octopusdeploy/data_environment.go
+++ b/octopusdeploy/data_environment.go
@@ -16,6 +16,14 @@ func dataEnvironment() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"use_guided_failure": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -37,7 +45,7 @@ func dataEnvironmentReadByName(d *schema.ResourceData, m interface{}) error {
 	d.SetId(env.ID)
 	d.Set("name", env.Name)
 	d.Set("description", env.Description)
-	d.Set("useguidedfailure", env.UseGuidedFailure)
+	d.Set("use_guided_failure", env.UseGuidedFailure)
 
 	return nil
 }

--- a/octopusdeploy/resource_environment.go
+++ b/octopusdeploy/resource_environment.go
@@ -23,7 +23,7 @@ func resourceEnvironment() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"useguidedfailure": &schema.Schema{
+			"use_guided_failure": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -49,7 +49,7 @@ func resourceEnvironmentRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("name", env.Name)
 	d.Set("description", env.Description)
-	d.Set("useguidedfailure", env.UseGuidedFailure)
+	d.Set("use_guided_failure", env.UseGuidedFailure)
 
 	return nil
 }
@@ -65,7 +65,7 @@ func buildEnvironmentResource(d *schema.ResourceData) *octopusdeploy.Environment
 		envDesc = envDescInterface.(string)
 	}
 
-	envGuidedInterface, ok := d.GetOk("useguidedfailure")
+	envGuidedInterface, ok := d.GetOk("use_guided_failure")
 	if ok {
 		envGuided = envGuidedInterface.(bool)
 	}

--- a/octopusdeploy/resource_environment_test.go
+++ b/octopusdeploy/resource_environment_test.go
@@ -28,7 +28,7 @@ func TestAccOctopusDeployEnvironmentBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						envPrefix, "description", envDesc),
 					resource.TestCheckResourceAttr(
-						envPrefix, "useguidedfailure", envGuided),
+						envPrefix, "use_guided_failure", envGuided),
 				),
 			},
 		},
@@ -40,7 +40,7 @@ func testEnvironmenttBasic(name, description, useguided string) string {
 		resource "octopusdeploy_environment" "foo" {
 			name           = "%s"
 			description    = "%s"
-			useguidedfailure = "%s"
+			use_guided_failure = "%s"
 		}
 		`,
 		name, description, useguided,

--- a/octopusdeploy/resource_machine_test.go
+++ b/octopusdeploy/resource_machine_test.go
@@ -35,11 +35,11 @@ func testMachineBasic(machineName string) string {
 	data "octopusdeploy_machinepolicy" "default" {
 		name = "Default Machine Policy"
 	}
-	  
+
 	resource "octopusdeploy_environment" "tf_test_env" {
 		name           = "OctopusTestMachineBasic"
 		description    = "Environment for testing Octopus Machines"
-		useguidedfailure = "false"
+		use_guided_failure = "false"
 	}
 
 	resource "octopusdeploy_machine" "foomac" {
@@ -49,7 +49,7 @@ func testMachineBasic(machineName string) string {
 		machinepolicy                   = "${data.octopusdeploy_machinepolicy.default.id}"
 		roles                           = ["Prod"]
 		tenanteddeploymentparticipation = "Untenanted"
-	  
+
 		endpoint {
 		  communicationstyle = "None"
 		  thumbprint         = ""


### PR DESCRIPTION
* The main README.md is getting a little out of hand
* Moving documentation over to a dedicated folder which matches how official providers document
* Documented decision 
* Environment Resource; renamed argument `useguidedfailure` to `use_guided_failure` and fixed data attributes so they are available