### PR TITLE
Generic deployment process

### DIFF
--- a/octopusdeploy/deployment_action.go
+++ b/octopusdeploy/deployment_action.go
@@ -24,7 +24,7 @@ func getDeploymentActionSchema() *schema.Schema {
 				},
 				"run_on_server": {
 					Type:        schema.TypeBool,
-					Description: "Whether this step is disabled",
+					Description: "Whether this step runs on a worker or on the target",
 					Optional:    true,
 					Default: 	 false,
 				},

--- a/octopusdeploy/deployment_action.go
+++ b/octopusdeploy/deployment_action.go
@@ -1,0 +1,122 @@
+package octopusdeploy
+
+import (
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func getDeploymentActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:        schema.TypeString,
+					Description: "The name of the action",
+					Required:    true,
+				},
+				"action_type": {
+					Type:        schema.TypeString,
+					Description: "The type of action",
+					Required:    true,
+				},
+				"disabled": {
+					Type:        schema.TypeBool,
+					Description: "Whether this step is disabled",
+					Optional:    true,
+					Default: 	 false,
+				},
+				"required": {
+					Type:        schema.TypeBool,
+					Description: "Whether this step is required and cannot be skipped",
+					Optional:    true,
+					Default: 	 false,
+				},
+				"worker_pool_id": {
+					Type:        schema.TypeString,
+					Description: "Which worker pool to run on",
+					Optional:    true,
+				},
+				"environments": &schema.Schema{
+					Description: "The environments that this step will run in",
+					Type:        schema.TypeList,
+					Optional:    true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"excluded_environments": &schema.Schema{
+					Description: "The environments that this still will be skipped in",
+					Type:        schema.TypeList,
+					Optional:    true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"channels": &schema.Schema{
+					Description: "The channels that this step applies to",
+					Type:        schema.TypeList,
+					Optional:    true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"tenant_tags": &schema.Schema{
+					Description: "The tags for the tenants that this step applies to",
+					Type:        schema.TypeList,
+					Optional:    true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"property": getPropertySchema(),
+				"primary_package": getPrimaryPackageSchema(),
+				"package": getPackageSchema(),
+			},
+		},
+	}
+}
+
+
+func buildDeploymentActionResource(tfAction map[string]interface{}) octopusdeploy.DeploymentAction {
+	action := octopusdeploy.DeploymentAction{
+		Name:                 tfAction["name"].(string),
+		ActionType:           tfAction["action_type"].(string),
+		IsDisabled:           tfAction["disabled"].(bool),
+		IsRequired:           tfAction["required"].(bool),
+		Environments:         getSliceFromTerraformTypeList(tfAction["environments"]),
+		ExcludedEnvironments: getSliceFromTerraformTypeList(tfAction["excluded_environments"]),
+		Channels:             getSliceFromTerraformTypeList(tfAction["channels"]),
+		TenantTags:           getSliceFromTerraformTypeList(tfAction["tenant_tags"]),
+		Properties:           map[string]string{},
+	}
+
+	workerPoolId := tfAction["worker_pool_id"]
+	if workerPoolId != nil {
+		action.WorkerPoolId = workerPoolId.(string)
+	}
+
+	if primaryPackage, ok := tfAction["primary_package"]; ok {
+		tfPrimaryPackage := primaryPackage.(*schema.Set).List()
+		primaryPackage := buildPackageReferenceResource(tfPrimaryPackage[0].(map[string]interface{}))
+		action.Packages = append(action.Packages, primaryPackage)
+	}
+
+	if tfPkgs, ok := tfAction["package"]; ok {
+		for _, tfPkg := range tfPkgs.(*schema.Set).List() {
+			pkg := buildPackageReferenceResource(tfPkg.(map[string]interface{}))
+			action.Packages = append(action.Packages, pkg)
+		}
+	}
+
+	if tfProps, ok := tfAction["property"]; ok {
+		for _, tfProp := range  tfProps.(*schema.Set).List() {
+			tfPropi := tfProp.(map[string]interface{})
+			action.Properties[tfPropi["key"].(string)] = tfPropi["value"].(string)
+		}
+	}
+
+	return action;
+}
+

--- a/octopusdeploy/deployment_process.go
+++ b/octopusdeploy/deployment_process.go
@@ -60,9 +60,9 @@ func buildDeploymentProcessResource(d *schema.ResourceData) *octopusdeploy.Deplo
 	}
 
 	if attr, ok := d.GetOk("step"); ok {
-		tfSteps := attr.(*schema.Set)
+		tfSteps := attr.([]interface {})
 
-		for _, tfStep := range tfSteps.List() {
+		for _, tfStep := range tfSteps {
 			step := buildDeploymentStepResource(tfStep.(map[string]interface{}))
 			deploymentProcess.Steps = append(deploymentProcess.Steps, step)
 		}

--- a/octopusdeploy/deployment_process.go
+++ b/octopusdeploy/deployment_process.go
@@ -5,7 +5,6 @@ import (
 	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
 	"github.com/hashicorp/terraform/helper/schema"
 	"log"
-	"strings"
 )
 
 func resourceDeploymentProcess() *schema.Resource {
@@ -20,221 +19,12 @@ func resourceDeploymentProcess() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"step": getStepSchema(),
+			"step": getDeploymentStepSchema(),
 		},
 	}
 }
 
 
-func getStepSchema() *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeSet,
-		Optional: true,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"name": {
-					Type:        schema.TypeString,
-					Description: "The name of the step",
-					Required:    true,
-				},
-				"target_roles": &schema.Schema{
-					Description: "The roles that this step run against, or runs on behalf of",
-					Type:        schema.TypeList,
-					Optional:    true,
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
-					},
-				},
-				"package_requirement": {
-					Type:        schema.TypeString,
-					Description: "Whether to run this step before or after package acquisition (if possible)",
-					Optional:    true,
-					Default:     (string)(octopusdeploy.DeploymentStepPackageRequirement_LetOctopusDecide),
-					ValidateFunc: validateValueFunc([]string{
-						(string)(octopusdeploy.DeploymentStepPackageRequirement_LetOctopusDecide),
-						(string)(octopusdeploy.DeploymentStepPackageRequirement_BeforePackageAcquisition),
-						(string)(octopusdeploy.DeploymentStepPackageRequirement_AfterPackageAcquisition),
-					}),
-				},
-				"condition": {
-					Type:        schema.TypeString,
-					Description: "When to run the step, one of 'Success', 'Failure', 'Always' or 'Variable'",
-					Optional:    true,
-					Default:     (string)(octopusdeploy.DeploymentStepCondition_Success),
-					ValidateFunc: validateValueFunc([]string{
-						(string)(octopusdeploy.DeploymentStepCondition_Success),
-						(string)(octopusdeploy.DeploymentStepCondition_Failure),
-						(string)(octopusdeploy.DeploymentStepCondition_Always),
-						(string)(octopusdeploy.DeploymentStepCondition_Variable),
-					}),
-				},
-				"condition_expression": {
-					Type:        schema.TypeString,
-					Description: "The expression to evaluate to determine whether to run this step when 'condition' is 'Variable'",
-					Optional:    true,
-				},
-				"start_trigger": {
-					Type:        schema.TypeString,
-					Description: "Whether to run this step after the previous step ('StartAfterPrevious') or at the same time as the previous step ('StartWithPrevious')",
-					Optional:    true,
-					Default:     (string)(octopusdeploy.DeploymentStepStartTrigger_StartAfterPrevious),
-					ValidateFunc: validateValueFunc([]string{
-						(string)(octopusdeploy.DeploymentStepStartTrigger_StartAfterPrevious),
-						(string)(octopusdeploy.DeploymentStepStartTrigger_StartWithPrevious),
-					}),
-				},
-				"window_size": {
-					Type:        schema.TypeString,
-					Description: "The maximum number of targets to deploy to simultaneously",
-					Optional:    true,
-				},
-				"action": getActionSchema(),
-			},
-		},
-	}
-}
-
-func getActionSchema() *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeSet,
-		Optional: true,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"name": {
-					Type:        schema.TypeString,
-					Description: "The name of the action",
-					Required:    true,
-				},
-				"action_type": {
-					Type:        schema.TypeString,
-					Description: "The type of action",
-					Required:    true,
-				},
-				"disabled": {
-					Type:        schema.TypeString,
-					Description: "Whether this step is disabled",
-					Optional:    true,
-					Default: 	 false,
-				},
-				"required": {
-					Type:        schema.TypeString,
-					Description: "Whether this step is required and cannot be skipped",
-					Optional:    true,
-					Default: 	 false,
-				},
-				"worker_pool_id": {
-					Type:        schema.TypeString,
-					Description: "Which worker pool to run on",
-					Optional:    true,
-				},
-				"environments": &schema.Schema{
-					Description: "The environments that this step will run in",
-					Type:        schema.TypeList,
-					Optional:    true,
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
-					},
-				},
-				"excluded_environments": &schema.Schema{
-					Description: "The environments that this still will be skipped in",
-					Type:        schema.TypeList,
-					Optional:    true,
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
-					},
-				},
-				"channels": &schema.Schema{
-					Description: "The channels that this step applies to",
-					Type:        schema.TypeList,
-					Optional:    true,
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
-					},
-				},
-				"tenant_tags": &schema.Schema{
-					Description: "The tags for the tenants that this step applies to",
-					Type:        schema.TypeList,
-					Optional:    true,
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
-					},
-				},
-				"property": getPropertySchema(),
-				"primary_package": getPrimaryPackageSchema(),
-				"package": getPackageSchema(),
-			},
-		},
-	}
-}
-
-func getPrimaryPackageSchema() *schema.Schema {
-	return &schema.Schema{
-		Description: "The primary package for the action",
-		Type:        schema.TypeSet,
-		Optional:    true,
-		MaxItems:	 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"package_id": {
-					Type:        schema.TypeString,
-					Description: "The ID of the package",
-					Required:    true,
-				},
-				"feed_id": {
-					Type:        schema.TypeString,
-					Description: "The feed to retrieve the package from",
-					Default: 	"feeds-builtin",
-					Optional:    true,
-				},
-				"acquisition_location": {
-					Type:        schema.TypeString,
-					Description: "Whether to acquire this package on the server ('Server'), target ('ExecutionTarget') or not at all ('NotAcquired'). Can be an expression",
-					Default:     (string)(octopusdeploy.PackageAcquisitionLocation_Server),
-					Optional:    true,
-				},
-			},
-		},
-	}
-}
-
-func getPackageSchema() *schema.Schema {
-	s := getPrimaryPackageSchema();
-	elementSchema := s.Elem.(*schema.Resource).Schema
-	elementSchema["name"] = &schema.Schema{
-		Type:        schema.TypeString,
-		Description: "The name of the package",
-		Required:    true,
-	}
-	elementSchema["extract_during_deployment"] = &schema.Schema{
-		Type:        schema.TypeString,
-		Description: "Whether to extract the package during deployment",
-		Optional:    true,
-	}
-	elementSchema["property"] = getPropertySchema()
-	return s
-}
-
-func getPropertySchema() *schema.Schema {
-	return &schema.Schema{
-		Description: "The tags for the tenants that this step applies to",
-		Type:        schema.TypeSet,
-		Optional:    true,
-		Elem:  &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"key": {
-					Type:        schema.TypeString,
-					Description: "The name of the action",
-					Required:    true,
-				},
-				"value": {
-					Type:        schema.TypeString,
-					Description: "The type of action",
-					Required:    true,
-				},
-			},
-		},
-	}
-}
 
 func resourceDeploymentProcessCreate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*octopusdeploy.Client)
@@ -243,10 +33,16 @@ func resourceDeploymentProcessCreate(d *schema.ResourceData, m interface{}) erro
 
 	project, err := client.Project.Get(newDeploymentProcess.ProjectID)
 	if err != nil {
-		return fmt.Errorf("error getting project %s: %s", newDeploymentProcess.ProjectID, err.Error())
+		return fmt.Errorf("error getting project %s: %s", project.Name, err.Error())
 	}
 
-	newDeploymentProcess.ID = project.DeploymentProcessID
+	current, err := client.DeploymentProcess.Get(project.DeploymentProcessID)
+	if err != nil {
+		return fmt.Errorf("error getting deployment process for %s: %s", project.Name, err.Error())
+	}
+
+	newDeploymentProcess.ID = current.ID
+	newDeploymentProcess.Version = current.Version
 	createdDeploymentProcess, err := client.DeploymentProcess.Update(newDeploymentProcess)
 
 	if err != nil {
@@ -267,122 +63,12 @@ func buildDeploymentProcessResource(d *schema.ResourceData) *octopusdeploy.Deplo
 		tfSteps := attr.(*schema.Set)
 
 		for _, tfStep := range tfSteps.List() {
-			step := buildStepResource(tfStep.(map[string]interface{}))
+			step := buildDeploymentStepResource(tfStep.(map[string]interface{}))
 			deploymentProcess.Steps = append(deploymentProcess.Steps, step)
 		}
 	}
 
 	return deploymentProcess
-}
-
-func buildStepResource(tfStep map[string]interface{}) octopusdeploy.DeploymentStep {
-	step := octopusdeploy.DeploymentStep{
-		Name: tfStep["name"].(string),
-		PackageRequirement: octopusdeploy.DeploymentStepPackageRequirement(tfStep["package_requirement"].(string)),
-		Condition: octopusdeploy.DeploymentStepCondition(tfStep["package_requirement"].(string)),
-		StartTrigger: octopusdeploy.DeploymentStepStartTrigger(tfStep["start_trigger"].(string)),
-	}
-
-	targetRoles := tfStep["target_roles"];
-	if targetRoles != nil {
-		step.Properties["Octopus.Action.TargetRoles"] = strings.Join(getSliceFromTerraformTypeList(targetRoles), ",")
-	}
-
-	conditionExpression := tfStep["condition_expression"]
-	if conditionExpression != nil {
-		step.Properties["Octopus.Action.ConditionVariableExpression"] = conditionExpression.(string)
-	}
-
-	windowSize := tfStep["window_size"]
-	if windowSize != nil {
-		step.Properties["Octopus.Action.ConditionVariableExpression"] = windowSize.(string)
-	}
-
-	if attr, ok := tfStep["action"]; ok {
-		tfActions := attr.([]interface {})
-
-		for _, tfAction := range tfActions {
-			action := buildActionResource(tfAction.(map[string]interface{}))
-			step.Actions = append(step.Actions, action)
-		}
-	}
-
-	return step;
-}
-
-func buildActionResource(tfAction map[string]interface{}) octopusdeploy.DeploymentAction {
-	action := octopusdeploy.DeploymentAction{
-		Name:                 tfAction["name"].(string),
-		ActionType:           tfAction["action_type"].(string),
-		IsDisabled:           tfAction["disabled"].(bool),
-		IsRequired:           tfAction["required"].(bool),
-		Environments:         getSliceFromTerraformTypeList(tfAction["environments"]),
-		ExcludedEnvironments: getSliceFromTerraformTypeList(tfAction["excluded_environments"]),
-		Channels:             getSliceFromTerraformTypeList(tfAction["channels"]),
-		TenantTags:           getSliceFromTerraformTypeList(tfAction["tenant_tags"]),
-	}
-
-	workerPoolId := tfAction["worker_pool_id"]
-	if workerPoolId != nil {
-		action.WorkerPoolId = workerPoolId.(string)
-	}
-
-	if primaryPackage, ok := tfAction["primary_package"]; ok {
-		tfPrimaryPackage := primaryPackage.([]interface {})
-		primaryPackage := buildPackageReferenceResource(tfPrimaryPackage[0].(map[string]interface{}))
-		action.Packages = append(action.Packages, primaryPackage)
-	}
-
-	if pkgAttr, ok := tfAction["package"]; ok {
-		tfPkgs := pkgAttr.([]interface {})
-
-		for _, tfPkg := range tfPkgs {
-			pkg := buildPackageReferenceResource(tfPkg.(map[string]interface{}))
-			action.Packages = append(action.Packages, pkg)
-		}
-	}
-
-	if propAttr, ok := tfAction["property"]; ok {
-		tfProps := propAttr.([]interface {})
-
-		for _, tfProp := range tfProps {
-			tfPropi := tfProp.(map[string]interface{})
-			action.Properties[tfPropi["key"].(string)] = tfPropi["value"].(string)
-		}
-	}
-
-	return action;
-}
-
-
-func buildPackageReferenceResource(tfPkg map[string]interface{}) octopusdeploy.PackageReference {
-	pkg := octopusdeploy.PackageReference{
-		PackageId:           tfPkg["package_id"].(string),
-		FeedId:              tfPkg["feed_id"].(string),
-		AcquisitionLocation: tfPkg["feed_id"].(string),
-	}
-
-	name := tfPkg["name"]
-	if name != nil {
-		pkg.Name = name.(string)
-	}
-
-
-	extract := tfPkg["extract_during_deployment"]
-	if extract != nil {
-		pkg.Properties["Extract"] = extract.(string)
-	}
-
-	if propAttr, ok := tfPkg["property"]; ok {
-		tfProps := propAttr.([]interface {})
-
-		for _, tfProp := range tfProps {
-			tfPropi := tfProp.(map[string]interface{})
-			pkg.Properties[tfPropi["key"].(string)] = tfPropi["value"].(string)
-		}
-	}
-
-	return pkg;
 }
 
 
@@ -414,9 +100,15 @@ func resourceDeploymentProcessUpdate(d *schema.ResourceData, m interface{}) erro
 
 	client := m.(*octopusdeploy.Client)
 
-	deploymentProcess, err := client.DeploymentProcess.Update(deploymentProcess)
-
+	current, err := client.DeploymentProcess.Get(deploymentProcess.ID)
 	if err != nil {
+		return fmt.Errorf("error getting deployment process %s: %s", deploymentProcess.ID, err.Error())
+	}
+
+	deploymentProcess.Version = current.Version
+		deploymentProcess, err = client.DeploymentProcess.Update(deploymentProcess)
+
+		if err != nil {
 		return fmt.Errorf("error updating deployment process id %s: %s", d.Id(), err.Error())
 	}
 
@@ -427,11 +119,18 @@ func resourceDeploymentProcessUpdate(d *schema.ResourceData, m interface{}) erro
 
 func resourceDeploymentProcessDelete(d *schema.ResourceData, m interface{}) error {
 	client := m.(*octopusdeploy.Client)
+	current, err := client.DeploymentProcess.Get(d.Id());
+
+	if err != nil {
+		return fmt.Errorf("error getting deployment process with id %s: %s", d.Id(), err.Error())
+	}
 
 	deploymentProcess := &octopusdeploy.DeploymentProcess{
 		ID: d.Id(),
+		Version: current.Version,
 	}
-	deploymentProcess, err := client.DeploymentProcess.Update(deploymentProcess)
+
+	deploymentProcess, err = client.DeploymentProcess.Update(deploymentProcess)
 
 	if err != nil {
 		return fmt.Errorf("error deleting deployment process with id %s: %s", deploymentProcess.ID, err.Error())

--- a/octopusdeploy/deployment_process.go
+++ b/octopusdeploy/deployment_process.go
@@ -1,0 +1,442 @@
+package octopusdeploy
+
+import (
+	"fmt"
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"strings"
+)
+
+func resourceDeploymentProcess() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDeploymentProcessCreate,
+		Read:   resourceDeploymentProcessRead,
+		Update: resourceDeploymentProcessUpdate,
+		Delete: resourceDeploymentProcessDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"step": getStepSchema(),
+		},
+	}
+}
+
+
+func getStepSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:        schema.TypeString,
+					Description: "The name of the step",
+					Required:    true,
+				},
+				"target_roles": &schema.Schema{
+					Description: "The roles that this step run against, or runs on behalf of",
+					Type:        schema.TypeList,
+					Optional:    true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"package_requirement": {
+					Type:        schema.TypeString,
+					Description: "Whether to run this step before or after package acquisition (if possible)",
+					Optional:    true,
+					Default:     (string)(octopusdeploy.DeploymentStepPackageRequirement_LetOctopusDecide),
+					ValidateFunc: validateValueFunc([]string{
+						(string)(octopusdeploy.DeploymentStepPackageRequirement_LetOctopusDecide),
+						(string)(octopusdeploy.DeploymentStepPackageRequirement_BeforePackageAcquisition),
+						(string)(octopusdeploy.DeploymentStepPackageRequirement_AfterPackageAcquisition),
+					}),
+				},
+				"condition": {
+					Type:        schema.TypeString,
+					Description: "When to run the step, one of 'Success', 'Failure', 'Always' or 'Variable'",
+					Optional:    true,
+					Default:     (string)(octopusdeploy.DeploymentStepCondition_Success),
+					ValidateFunc: validateValueFunc([]string{
+						(string)(octopusdeploy.DeploymentStepCondition_Success),
+						(string)(octopusdeploy.DeploymentStepCondition_Failure),
+						(string)(octopusdeploy.DeploymentStepCondition_Always),
+						(string)(octopusdeploy.DeploymentStepCondition_Variable),
+					}),
+				},
+				"condition_expression": {
+					Type:        schema.TypeString,
+					Description: "The expression to evaluate to determine whether to run this step when 'condition' is 'Variable'",
+					Optional:    true,
+				},
+				"start_trigger": {
+					Type:        schema.TypeString,
+					Description: "Whether to run this step after the previous step ('StartAfterPrevious') or at the same time as the previous step ('StartWithPrevious')",
+					Optional:    true,
+					Default:     (string)(octopusdeploy.DeploymentStepStartTrigger_StartAfterPrevious),
+					ValidateFunc: validateValueFunc([]string{
+						(string)(octopusdeploy.DeploymentStepStartTrigger_StartAfterPrevious),
+						(string)(octopusdeploy.DeploymentStepStartTrigger_StartWithPrevious),
+					}),
+				},
+				"window_size": {
+					Type:        schema.TypeString,
+					Description: "The maximum number of targets to deploy to simultaneously",
+					Optional:    true,
+				},
+				"action": getActionSchema(),
+			},
+		},
+	}
+}
+
+func getActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:        schema.TypeString,
+					Description: "The name of the action",
+					Required:    true,
+				},
+				"action_type": {
+					Type:        schema.TypeString,
+					Description: "The type of action",
+					Required:    true,
+				},
+				"disabled": {
+					Type:        schema.TypeString,
+					Description: "Whether this step is disabled",
+					Optional:    true,
+					Default: 	 false,
+				},
+				"required": {
+					Type:        schema.TypeString,
+					Description: "Whether this step is required and cannot be skipped",
+					Optional:    true,
+					Default: 	 false,
+				},
+				"worker_pool_id": {
+					Type:        schema.TypeString,
+					Description: "Which worker pool to run on",
+					Optional:    true,
+				},
+				"environments": &schema.Schema{
+					Description: "The environments that this step will run in",
+					Type:        schema.TypeList,
+					Optional:    true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"excluded_environments": &schema.Schema{
+					Description: "The environments that this still will be skipped in",
+					Type:        schema.TypeList,
+					Optional:    true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"channels": &schema.Schema{
+					Description: "The channels that this step applies to",
+					Type:        schema.TypeList,
+					Optional:    true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"tenant_tags": &schema.Schema{
+					Description: "The tags for the tenants that this step applies to",
+					Type:        schema.TypeList,
+					Optional:    true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"property": getPropertySchema(),
+				"primary_package": getPrimaryPackageSchema(),
+				"package": getPackageSchema(),
+			},
+		},
+	}
+}
+
+func getPrimaryPackageSchema() *schema.Schema {
+	return &schema.Schema{
+		Description: "The primary package for the action",
+		Type:        schema.TypeSet,
+		Optional:    true,
+		MaxItems:	 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"package_id": {
+					Type:        schema.TypeString,
+					Description: "The ID of the package",
+					Required:    true,
+				},
+				"feed_id": {
+					Type:        schema.TypeString,
+					Description: "The feed to retrieve the package from",
+					Default: 	"feeds-builtin",
+					Optional:    true,
+				},
+				"acquisition_location": {
+					Type:        schema.TypeString,
+					Description: "Whether to acquire this package on the server ('Server'), target ('ExecutionTarget') or not at all ('NotAcquired'). Can be an expression",
+					Default:     (string)(octopusdeploy.PackageAcquisitionLocation_Server),
+					Optional:    true,
+				},
+			},
+		},
+	}
+}
+
+func getPackageSchema() *schema.Schema {
+	s := getPrimaryPackageSchema();
+	elementSchema := s.Elem.(*schema.Resource).Schema
+	elementSchema["name"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "The name of the package",
+		Required:    true,
+	}
+	elementSchema["extract_during_deployment"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "Whether to extract the package during deployment",
+		Optional:    true,
+	}
+	elementSchema["property"] = getPropertySchema()
+	return s
+}
+
+func getPropertySchema() *schema.Schema {
+	return &schema.Schema{
+		Description: "The tags for the tenants that this step applies to",
+		Type:        schema.TypeSet,
+		Optional:    true,
+		Elem:  &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"key": {
+					Type:        schema.TypeString,
+					Description: "The name of the action",
+					Required:    true,
+				},
+				"value": {
+					Type:        schema.TypeString,
+					Description: "The type of action",
+					Required:    true,
+				},
+			},
+		},
+	}
+}
+
+func resourceDeploymentProcessCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*octopusdeploy.Client)
+
+	newDeploymentProcess := buildDeploymentProcessResource(d)
+
+	project, err := client.Project.Get(newDeploymentProcess.ProjectID)
+	if err != nil {
+		return fmt.Errorf("error getting project %s: %s", newDeploymentProcess.ProjectID, err.Error())
+	}
+
+	newDeploymentProcess.ID = project.DeploymentProcessID
+	createdDeploymentProcess, err := client.DeploymentProcess.Update(newDeploymentProcess)
+
+	if err != nil {
+		return fmt.Errorf("error creating deployment process: %s", err.Error())
+	}
+
+	d.SetId(createdDeploymentProcess.ID)
+
+	return nil
+}
+
+func buildDeploymentProcessResource(d *schema.ResourceData) *octopusdeploy.DeploymentProcess {
+	deploymentProcess := &octopusdeploy.DeploymentProcess {
+		ProjectID: d.Get("project_id").(string),
+	}
+
+	if attr, ok := d.GetOk("step"); ok {
+		tfSteps := attr.(*schema.Set)
+
+		for _, tfStep := range tfSteps.List() {
+			step := buildStepResource(tfStep.(map[string]interface{}))
+			deploymentProcess.Steps = append(deploymentProcess.Steps, step)
+		}
+	}
+
+	return deploymentProcess
+}
+
+func buildStepResource(tfStep map[string]interface{}) octopusdeploy.DeploymentStep {
+	step := octopusdeploy.DeploymentStep{
+		Name: tfStep["name"].(string),
+		PackageRequirement: octopusdeploy.DeploymentStepPackageRequirement(tfStep["package_requirement"].(string)),
+		Condition: octopusdeploy.DeploymentStepCondition(tfStep["package_requirement"].(string)),
+		StartTrigger: octopusdeploy.DeploymentStepStartTrigger(tfStep["start_trigger"].(string)),
+	}
+
+	targetRoles := tfStep["target_roles"];
+	if targetRoles != nil {
+		step.Properties["Octopus.Action.TargetRoles"] = strings.Join(getSliceFromTerraformTypeList(targetRoles), ",")
+	}
+
+	conditionExpression := tfStep["condition_expression"]
+	if conditionExpression != nil {
+		step.Properties["Octopus.Action.ConditionVariableExpression"] = conditionExpression.(string)
+	}
+
+	windowSize := tfStep["window_size"]
+	if windowSize != nil {
+		step.Properties["Octopus.Action.ConditionVariableExpression"] = windowSize.(string)
+	}
+
+	if attr, ok := tfStep["action"]; ok {
+		tfActions := attr.([]interface {})
+
+		for _, tfAction := range tfActions {
+			action := buildActionResource(tfAction.(map[string]interface{}))
+			step.Actions = append(step.Actions, action)
+		}
+	}
+
+	return step;
+}
+
+func buildActionResource(tfAction map[string]interface{}) octopusdeploy.DeploymentAction {
+	action := octopusdeploy.DeploymentAction{
+		Name:                 tfAction["name"].(string),
+		ActionType:           tfAction["action_type"].(string),
+		IsDisabled:           tfAction["disabled"].(bool),
+		IsRequired:           tfAction["required"].(bool),
+		Environments:         getSliceFromTerraformTypeList(tfAction["environments"]),
+		ExcludedEnvironments: getSliceFromTerraformTypeList(tfAction["excluded_environments"]),
+		Channels:             getSliceFromTerraformTypeList(tfAction["channels"]),
+		TenantTags:           getSliceFromTerraformTypeList(tfAction["tenant_tags"]),
+	}
+
+	workerPoolId := tfAction["worker_pool_id"]
+	if workerPoolId != nil {
+		action.WorkerPoolId = workerPoolId.(string)
+	}
+
+	if primaryPackage, ok := tfAction["primary_package"]; ok {
+		tfPrimaryPackage := primaryPackage.([]interface {})
+		primaryPackage := buildPackageReferenceResource(tfPrimaryPackage[0].(map[string]interface{}))
+		action.Packages = append(action.Packages, primaryPackage)
+	}
+
+	if pkgAttr, ok := tfAction["package"]; ok {
+		tfPkgs := pkgAttr.([]interface {})
+
+		for _, tfPkg := range tfPkgs {
+			pkg := buildPackageReferenceResource(tfPkg.(map[string]interface{}))
+			action.Packages = append(action.Packages, pkg)
+		}
+	}
+
+	if propAttr, ok := tfAction["property"]; ok {
+		tfProps := propAttr.([]interface {})
+
+		for _, tfProp := range tfProps {
+			tfPropi := tfProp.(map[string]interface{})
+			action.Properties[tfPropi["key"].(string)] = tfPropi["value"].(string)
+		}
+	}
+
+	return action;
+}
+
+
+func buildPackageReferenceResource(tfPkg map[string]interface{}) octopusdeploy.PackageReference {
+	pkg := octopusdeploy.PackageReference{
+		PackageId:           tfPkg["package_id"].(string),
+		FeedId:              tfPkg["feed_id"].(string),
+		AcquisitionLocation: tfPkg["feed_id"].(string),
+	}
+
+	name := tfPkg["name"]
+	if name != nil {
+		pkg.Name = name.(string)
+	}
+
+
+	extract := tfPkg["extract_during_deployment"]
+	if extract != nil {
+		pkg.Properties["Extract"] = extract.(string)
+	}
+
+	if propAttr, ok := tfPkg["property"]; ok {
+		tfProps := propAttr.([]interface {})
+
+		for _, tfProp := range tfProps {
+			tfPropi := tfProp.(map[string]interface{})
+			pkg.Properties[tfPropi["key"].(string)] = tfPropi["value"].(string)
+		}
+	}
+
+	return pkg;
+}
+
+
+func resourceDeploymentProcessRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*octopusdeploy.Client)
+
+	deploymentProcessID := d.Id()
+
+	_, err := client.DeploymentProcess.Get(deploymentProcessID)
+
+	if err == octopusdeploy.ErrItemNotFound {
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading deployment process id %s: %s", deploymentProcessID, err.Error())
+	}
+
+	log.Printf("[DEBUG] deploymentProcess: %v", m)
+
+	return nil
+}
+
+
+func resourceDeploymentProcessUpdate(d *schema.ResourceData, m interface{}) error {
+	deploymentProcess := buildDeploymentProcessResource(d)
+	deploymentProcess.ID = d.Id() // set deploymentProcess struct ID so octopus knows which deploymentProcess to update
+
+	client := m.(*octopusdeploy.Client)
+
+	deploymentProcess, err := client.DeploymentProcess.Update(deploymentProcess)
+
+	if err != nil {
+		return fmt.Errorf("error updating deployment process id %s: %s", d.Id(), err.Error())
+	}
+
+	d.SetId(deploymentProcess.ID)
+
+	return nil
+}
+
+func resourceDeploymentProcessDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*octopusdeploy.Client)
+
+	deploymentProcess := &octopusdeploy.DeploymentProcess{
+		ID: d.Id(),
+	}
+	deploymentProcess, err := client.DeploymentProcess.Update(deploymentProcess)
+
+	if err != nil {
+		return fmt.Errorf("error deleting deployment process with id %s: %s", deploymentProcess.ID, err.Error())
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/octopusdeploy/deployment_process_test.go
+++ b/octopusdeploy/deployment_process_test.go
@@ -141,7 +141,7 @@ func testAccCheckOctopusDeployDeploymentProcess() resource.TestCheckFunc {
 			return err
 		}
 
-		expectedNumberOfSteps := 1
+		expectedNumberOfSteps := 2
 		numberOfSteps := len(process.Steps)
 		if numberOfSteps != expectedNumberOfSteps {
 			return fmt.Errorf("Deployment process has %d steps instead of the expected %d", numberOfSteps, expectedNumberOfSteps)

--- a/octopusdeploy/deployment_process_test.go
+++ b/octopusdeploy/deployment_process_test.go
@@ -1,0 +1,144 @@
+package octopusdeploy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOctopusDeployDeploymentProcessBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckOctopusDeployDeploymentProcessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeploymentProcessBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOctopusDeployDeploymentProcess(),
+				),
+			},
+		},
+	})
+}
+
+func testAccDeploymentProcessBasic() string {
+	return `
+		resource "octopusdeploy_lifecycle" "test" {
+			name = "Test Lifecycle"
+		}
+
+		resource "octopusdeploy_project_group" "test" {
+			name = "Test Group"
+		}
+
+		resource "octopusdeploy_project" "test" {
+			name             = "Test Project"
+			lifecycle_id     = "${octopusdeploy_lifecycle.test.id}"
+			project_group_id = "${octopusdeploy_project_group.test.id}"
+		}
+
+		resource "octopusdeploy_deployment_process" "test" {
+			project_id = "${octopusdeploy_project.test.id}"
+
+			step {
+				name = "Test"
+				target_roles = ["A", "B"]
+				package_requirement = "BeforePackageAcquisition"
+				condition = "Variable"
+				condition_expression = "#{run}"
+				start_trigger = "StartWithPrevious"
+				window_size = "5"
+				
+
+				action {
+					name = "Test"
+					action_type = "Octopus.Script"
+					disabled = false
+					required = true
+					worker_pool_id = "WorkerPools-1"
+					environments = ["Environments-1"]
+					excluded_environments = ["Environments-2"]
+					channels = ["Channels-1"]
+					tenant_tags = ["tag/tag"]
+					
+					primary_package {
+						package_id = "MyPackage"
+						feed_id = "feeds-builtin"
+						acquisition_location = "ExecutionTarget"
+					}
+
+					package {
+						name = "ThePackage"
+						package_id = "MyPackage"
+						feed_id = "feeds-builtin"
+						acquisition_location = "NotAcquired"
+						extract_during_deployment = true
+
+						property {
+							key = "WhatIsThis"
+							value = "Dunno"
+						}
+
+					}
+
+					property {
+						key = "Octopus.Action.RunOnServer"
+						value = "true"
+					}
+				}
+			}
+		}
+		`
+}
+
+func testAccCheckOctopusDeployDeploymentProcessDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*octopusdeploy.Client)
+
+	if err := destroyProjectHelper(s, client); err != nil {
+		return err
+	}
+	if err := destroyHelperProjectGroup(s, client); err != nil {
+		return err
+	}
+	if err := destroyHelperLifecycle(s, client); err != nil {
+		return err
+	}
+	return nil
+}
+
+func testAccCheckOctopusDeployDeploymentProcess() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*octopusdeploy.Client)
+
+		process, err := getDeploymentProcess(s, client);
+		if err != nil {
+			return err
+		}
+
+		expectedNumberOfSteps := 1
+		numberOfSteps := len(process.Steps)
+		if numberOfSteps != expectedNumberOfSteps {
+			return fmt.Errorf("Deployment process has %d steps instead of the expected %d", numberOfSteps, expectedNumberOfSteps)
+		}
+
+		if process.Steps[0].Actions[0].Properties["Octopus.Action.RunOnServer"] != "true" {
+			return fmt.Errorf("The RunOnServer property has not been set to true on the deployment process")
+		}
+
+		return nil;
+	}
+}
+
+
+func getDeploymentProcess(s *terraform.State, client *octopusdeploy.Client) (*octopusdeploy.DeploymentProcess, error) {
+	for _, r := range s.RootModule().Resources {
+		if r.Type == "octopusdeploy_deployment_process" {
+			return client.DeploymentProcess.Get(r.Primary.ID);
+		}
+	}
+	return nil, fmt.Errorf("No deployment process found in the terraform resources")
+}

--- a/octopusdeploy/deployment_process_test.go
+++ b/octopusdeploy/deployment_process_test.go
@@ -47,7 +47,7 @@ func testAccDeploymentProcessBasic() string {
 			step {
 				name = "Test"
 				target_roles = ["A", "B"]
-				package_requirement = "BeforePackageAcquisition"
+				package_requirement = "AfterPackageAcquisition"
 				condition = "Variable"
 				condition_expression = "#{run}"
 				start_trigger = "StartWithPrevious"
@@ -61,9 +61,9 @@ func testAccDeploymentProcessBasic() string {
 					required = true
 					worker_pool_id = "WorkerPools-1"
 					environments = ["Environments-1"]
-					excluded_environments = ["Environments-2"]
-					channels = ["Channels-1"]
-					tenant_tags = ["tag/tag"]
+					//excluded_environments = ["Environments-2"]
+					//channels = ["Channels-1"]
+					//tenant_tags = ["tag/tag"]
 					
 					primary_package {
 						package_id = "MyPackage"
@@ -86,9 +86,15 @@ func testAccDeploymentProcessBasic() string {
 					}
 
 					property {
-						key = "Octopus.Action.RunOnServer"
-						value = "true"
+						key = "Octopus.Action.Script.ScriptFileName"
+						value = "Run.ps132"
 					}
+
+					property {
+						key = "Octopus.Action.Script.ScriptSource"
+						value = "Package"
+					}
+
 				}
 			}
 		}

--- a/octopusdeploy/deployment_process_test.go
+++ b/octopusdeploy/deployment_process_test.go
@@ -97,6 +97,22 @@ func testAccDeploymentProcessBasic() string {
 
 				}
 			}
+
+ step {
+        name = "Step2"
+        start_trigger = "StartWithPrevious"
+
+        action {
+            name = "Step2"
+            action_type = "Octopus.Script"
+            run_on_server = true
+
+            property {
+                key = "Octopus.Action.Script.ScriptBody"
+                value = "Write-Host 'hi'"
+            }
+        }
+    }
 		}
 		`
 }

--- a/octopusdeploy/deployment_step.go
+++ b/octopusdeploy/deployment_step.go
@@ -9,7 +9,7 @@ import (
 
 func getDeploymentStepSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeSet,
+		Type:     schema.TypeList,
 		Optional: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -96,11 +96,11 @@ func buildDeploymentStepResource(tfStep map[string]interface{}) octopusdeploy.De
 
 	windowSize := tfStep["window_size"]
 	if windowSize != nil {
-		step.Properties["Octopus.Action.ConditionVariableExpression"] = windowSize.(string)
+		step.Properties["Octopus.Action.MaxParallelism"] = windowSize.(string)
 	}
 
 	if attr, ok := tfStep["action"]; ok {
-		for _, tfAction := range attr.(*schema.Set).List() {
+		for _, tfAction := range attr.([]interface {}) {
 			action := buildDeploymentActionResource(tfAction.(map[string]interface{}))
 			step.Actions = append(step.Actions, action)
 		}

--- a/octopusdeploy/deployment_step.go
+++ b/octopusdeploy/deployment_step.go
@@ -1,0 +1,111 @@
+package octopusdeploy
+
+import (
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+	"strings"
+)
+
+
+func getDeploymentStepSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:        schema.TypeString,
+					Description: "The name of the step",
+					Required:    true,
+				},
+				"target_roles": &schema.Schema{
+					Description: "The roles that this step run against, or runs on behalf of",
+					Type:        schema.TypeList,
+					Optional:    true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"package_requirement": {
+					Type:        schema.TypeString,
+					Description: "Whether to run this step before or after package acquisition (if possible)",
+					Optional:    true,
+					Default:     (string)(octopusdeploy.DeploymentStepPackageRequirement_LetOctopusDecide),
+					ValidateFunc: validateValueFunc([]string{
+						(string)(octopusdeploy.DeploymentStepPackageRequirement_LetOctopusDecide),
+						(string)(octopusdeploy.DeploymentStepPackageRequirement_BeforePackageAcquisition),
+						(string)(octopusdeploy.DeploymentStepPackageRequirement_AfterPackageAcquisition),
+					}),
+				},
+				"condition": {
+					Type:        schema.TypeString,
+					Description: "When to run the step, one of 'Success', 'Failure', 'Always' or 'Variable'",
+					Optional:    true,
+					Default:     (string)(octopusdeploy.DeploymentStepCondition_Success),
+					ValidateFunc: validateValueFunc([]string{
+						(string)(octopusdeploy.DeploymentStepCondition_Success),
+						(string)(octopusdeploy.DeploymentStepCondition_Failure),
+						(string)(octopusdeploy.DeploymentStepCondition_Always),
+						(string)(octopusdeploy.DeploymentStepCondition_Variable),
+					}),
+				},
+				"condition_expression": {
+					Type:        schema.TypeString,
+					Description: "The expression to evaluate to determine whether to run this step when 'condition' is 'Variable'",
+					Optional:    true,
+				},
+				"start_trigger": {
+					Type:        schema.TypeString,
+					Description: "Whether to run this step after the previous step ('StartAfterPrevious') or at the same time as the previous step ('StartWithPrevious')",
+					Optional:    true,
+					Default:     (string)(octopusdeploy.DeploymentStepStartTrigger_StartAfterPrevious),
+					ValidateFunc: validateValueFunc([]string{
+						(string)(octopusdeploy.DeploymentStepStartTrigger_StartAfterPrevious),
+						(string)(octopusdeploy.DeploymentStepStartTrigger_StartWithPrevious),
+					}),
+				},
+				"window_size": {
+					Type:        schema.TypeString,
+					Description: "The maximum number of targets to deploy to simultaneously",
+					Optional:    true,
+				},
+				"action": getDeploymentActionSchema(),
+			},
+		},
+	}
+}
+
+func buildDeploymentStepResource(tfStep map[string]interface{}) octopusdeploy.DeploymentStep {
+	step := octopusdeploy.DeploymentStep{
+		Name: tfStep["name"].(string),
+		PackageRequirement: octopusdeploy.DeploymentStepPackageRequirement(tfStep["package_requirement"].(string)),
+		Condition: octopusdeploy.DeploymentStepCondition(tfStep["condition"].(string)),
+		StartTrigger: octopusdeploy.DeploymentStepStartTrigger(tfStep["start_trigger"].(string)),
+		Properties: map[string]string{},
+	}
+
+	targetRoles := tfStep["target_roles"];
+	if targetRoles != nil {
+		step.Properties["Octopus.Action.TargetRoles"] = strings.Join(getSliceFromTerraformTypeList(targetRoles), ",")
+	}
+
+	conditionExpression := tfStep["condition_expression"]
+	if conditionExpression != nil {
+		step.Properties["Octopus.Action.ConditionVariableExpression"] = conditionExpression.(string)
+	}
+
+	windowSize := tfStep["window_size"]
+	if windowSize != nil {
+		step.Properties["Octopus.Action.ConditionVariableExpression"] = windowSize.(string)
+	}
+
+	if attr, ok := tfStep["action"]; ok {
+		for _, tfAction := range attr.(*schema.Set).List() {
+			action := buildDeploymentActionResource(tfAction.(map[string]interface{}))
+			step.Actions = append(step.Actions, action)
+		}
+	}
+
+	return step;
+}
+

--- a/octopusdeploy/package_reference.go
+++ b/octopusdeploy/package_reference.go
@@ -1,0 +1,72 @@
+package octopusdeploy
+
+import (
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+
+func getPrimaryPackageSchema() *schema.Schema {
+	return &schema.Schema{
+		Description: "The primary package for the action",
+		Type:        schema.TypeSet,
+		Optional:    true,
+		MaxItems:	 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"package_id": {
+					Type:        schema.TypeString,
+					Description: "The ID of the package",
+					Required:    true,
+				},
+				"feed_id": {
+					Type:        schema.TypeString,
+					Description: "The feed to retrieve the package from",
+					Default: 	"feeds-builtin",
+					Optional:    true,
+				},
+				"acquisition_location": {
+					Type:        schema.TypeString,
+					Description: "Whether to acquire this package on the server ('Server'), target ('ExecutionTarget') or not at all ('NotAcquired'). Can be an expression",
+					Default:     (string)(octopusdeploy.PackageAcquisitionLocation_Server),
+					Optional:    true,
+				},
+				"property": getPropertySchema(),
+			},
+		},
+	}
+}
+
+func getPackageSchema() *schema.Schema {
+	s := getPrimaryPackageSchema();
+	elementSchema := s.Elem.(*schema.Resource).Schema
+	elementSchema["name"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "The name of the package",
+		Required:    true,
+	}
+	elementSchema["extract_during_deployment"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "Whether to extract the package during deployment",
+		Optional:    true,
+	}
+	return s
+}
+
+func buildPackageReferenceResource(tfPkg map[string]interface{}) octopusdeploy.PackageReference {
+	pkg := octopusdeploy.PackageReference{
+		Name:                getStringOrEmpty(tfPkg["name"]),
+		PackageId:           tfPkg["package_id"].(string),
+		FeedId:              tfPkg["feed_id"].(string),
+		AcquisitionLocation: tfPkg["acquisition_location"].(string),
+		Properties:          buildPropertiesMap(tfPkg["property"]),
+	}
+
+	extract := tfPkg["extract_during_deployment"]
+	if extract != nil {
+		pkg.Properties["Extract"] = extract.(string)
+	}
+
+	return pkg;
+}
+

--- a/octopusdeploy/package_reference.go
+++ b/octopusdeploy/package_reference.go
@@ -49,6 +49,7 @@ func getPackageSchema() *schema.Schema {
 		Type:        schema.TypeString,
 		Description: "Whether to extract the package during deployment",
 		Optional:    true,
+		Default:     "true",
 	}
 	return s
 }

--- a/octopusdeploy/property.go
+++ b/octopusdeploy/property.go
@@ -1,0 +1,35 @@
+package octopusdeploy
+
+import "github.com/hashicorp/terraform/helper/schema"
+
+func getPropertySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Optional:    true,
+		Elem:  &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"key": {
+					Type:        schema.TypeString,
+					Description: "The name of the action",
+					Required:    true,
+				},
+				"value": {
+					Type:        schema.TypeString,
+					Description: "The type of action",
+					Required:    true,
+				},
+			},
+		},
+	}
+}
+
+func buildPropertiesMap(tfProperties interface {}) map[string]string {
+	properties := map[string]string{};
+	if tfProperties != nil {
+		for _, tfProp := range tfProperties.(*schema.Set).List() {
+			m := tfProp.(map[string]interface {})
+			properties[m["key"].(string)] = m["value"].(string)
+		}
+	}
+	return properties;
+}

--- a/octopusdeploy/provider.go
+++ b/octopusdeploy/provider.go
@@ -28,6 +28,7 @@ func Provider() terraform.ResourceProvider {
 			"octopusdeploy_machine":                           resourceMachine(),
 			"octopusdeploy_library_variable_set":              resourceLibraryVariableSet(),
 			"octopusdeploy_lifecycle":                         resourceLifecycle(),
+			"octopusdeploy_deployment_process":                resourceDeploymentProcess(),
 		},
 		Schema: map[string]*schema.Schema{
 			"address": &schema.Schema{

--- a/octopusdeploy/resource_project.go
+++ b/octopusdeploy/resource_project.go
@@ -365,15 +365,15 @@ func buildDeploymentProcess(d *schema.ResourceData, deploymentProcess *octopusde
 			serviceAccount := localStep["service_account"].(string)
 			serviceName := localStep["service_name"].(string)
 			serviceStartMode := localStep["service_start_mode"].(string)
-			stepCondition := localStep["step_condition"].(string)
+			stepCondition :=localStep["step_condition"].(string)
 			stepName := localStep["step_name"].(string)
 			stepStartTrigger := localStep["step_start_trigger"].(string)
 
 			deploymentStep := &octopusdeploy.DeploymentStep{
 				Name:               stepName,
 				PackageRequirement: "LetOctopusDecide",
-				Condition:          stepCondition,
-				StartTrigger:       stepStartTrigger,
+				Condition:          octopusdeploy.DeploymentStepCondition(stepCondition),
+				StartTrigger:       octopusdeploy.DeploymentStepStartTrigger(stepStartTrigger),
 				Actions: []octopusdeploy.DeploymentAction{
 					{
 						Name:       stepName,
@@ -443,8 +443,8 @@ func buildDeploymentProcess(d *schema.ResourceData, deploymentProcess *octopusde
 			deploymentStep := &octopusdeploy.DeploymentStep{
 				Name:               stepName,
 				PackageRequirement: "LetOctopusDecide",
-				Condition:          stepCondition,
-				StartTrigger:       stepStartTrigger,
+				Condition:          octopusdeploy.DeploymentStepCondition(stepCondition),
+				StartTrigger:       octopusdeploy.DeploymentStepStartTrigger(stepStartTrigger),
 				Actions: []octopusdeploy.DeploymentAction{
 					{
 						Name:       stepName,
@@ -515,8 +515,8 @@ func buildDeploymentProcess(d *schema.ResourceData, deploymentProcess *octopusde
 			deploymentStep := &octopusdeploy.DeploymentStep{
 				Name:               stepName,
 				PackageRequirement: "LetOctopusDecide",
-				Condition:          stepCondition,
-				StartTrigger:       stepStartTrigger,
+				Condition:          octopusdeploy.DeploymentStepCondition(stepCondition),
+				StartTrigger:       octopusdeploy.DeploymentStepStartTrigger(stepStartTrigger),
 				Actions: []octopusdeploy.DeploymentAction{
 					{
 						Name:       stepName,
@@ -566,8 +566,8 @@ func buildDeploymentProcess(d *schema.ResourceData, deploymentProcess *octopusde
 			deploymentStep := &octopusdeploy.DeploymentStep{
 				Name:               stepName,
 				PackageRequirement: "LetOctopusDecide",
-				Condition:          stepCondition,
-				StartTrigger:       stepStartTrigger,
+				Condition:          octopusdeploy.DeploymentStepCondition(stepCondition),
+				StartTrigger:       octopusdeploy.DeploymentStepStartTrigger(stepStartTrigger),
 				Actions: []octopusdeploy.DeploymentAction{
 					{
 						Name:       stepName,

--- a/octopusdeploy/resource_project_test.go
+++ b/octopusdeploy/resource_project_test.go
@@ -340,7 +340,7 @@ func testAccWithDeploymentStepWindowsService(name, lifeCycleID, projectGroupID, 
 func testAccCheckOctopusDeployProjectDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*octopusdeploy.Client)
 
-	if err := destroyHelper(s, client); err != nil {
+	if err := destroyProjectHelper(s, client); err != nil {
 		return err
 	}
 	return nil
@@ -356,7 +356,7 @@ func testAccCheckOctopusDeployProjectExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func destroyHelper(s *terraform.State, client *octopusdeploy.Client) error {
+func destroyProjectHelper(s *terraform.State, client *octopusdeploy.Client) error {
 	for _, r := range s.RootModule().Resources {
 		if _, err := client.Project.Get(r.Primary.ID); err != nil {
 			if err == octopusdeploy.ErrItemNotFound {

--- a/octopusdeploy/util.go
+++ b/octopusdeploy/util.go
@@ -62,3 +62,11 @@ func getSliceFromTerraformTypeList(inputTypeList interface{}) []string {
 
 	return newSlice
 }
+
+func getStringOrEmpty(tfAttr interface{}) string {
+	if(tfAttr == nil) {
+		return "";
+	}
+	return tfAttr.(string);
+
+}

--- a/vendor/github.com/MattHodge/go-octopusdeploy/octopusdeploy/deployment_process.go
+++ b/vendor/github.com/MattHodge/go-octopusdeploy/octopusdeploy/deployment_process.go
@@ -29,35 +29,76 @@ type DeploymentProcess struct {
 	LastSnapshotID string           `json:"LastSnapshotId,omitempty"`
 	Links          Links            `json:"Links,omitempty"`
 	ProjectID      string           `json:"ProjectId,omitempty"`
-	Steps          []DeploymentStep `json:"Steps"`
-	Version        *int32           `json:"Version"`
+	Steps          []DeploymentStep `json:"Steps,omitempty"`
+	Version        int32            `json:"Version"`
 }
 
 type DeploymentStep struct {
-	ID                 string             `json:"Id"`
-	Name               string             `json:"Name"`
-	PackageRequirement string             `json:"PackageRequirement,omitempty"`                                         // may need its own model / enum
-	Properties         map[string]string  `json:"Properties"`                                                           // TODO: refactor to use the PropertyValueResource for handling sensitive values - https://blog.gopheracademy.com/advent-2016/advanced-encoding-decoding/
-	Condition          string             `json:"Condition,omitempty" validate:"oneof=Success Failure Always Variable"` // variable option adds a Property "Octopus.Action.ConditionVariableExpression"
-	StartTrigger       string             `json:"StartTrigger,omitempty" validate:"oneof=StartAfterPrevious StartWithPrevious"`
-	Actions            []DeploymentAction `json:"Actions"`
+	ID                 string                           `json:"Id,omitempty"`
+	Name               string                           `json:"Name"`
+	PackageRequirement DeploymentStepPackageRequirement `json:"PackageRequirement,omitempty"`                                         // may need its own model / enum
+	Properties         map[string]string                `json:"Properties"`                                                           // TODO: refactor to use the PropertyValueResource for handling sensitive values - https://blog.gopheracademy.com/advent-2016/advanced-encoding-decoding/
+	Condition          DeploymentStepCondition          `json:"Condition,omitempty" validate:"oneof=Success Failure Always Variable"` // variable option adds a Property "Octopus.Action.ConditionVariableExpression"
+	StartTrigger       DeploymentStepStartTrigger       `json:"StartTrigger,omitempty" validate:"oneof=StartAfterPrevious StartWithPrevious"`
+	Actions            []DeploymentAction               `json:"Actions,omitempty"`
 }
 
 type DeploymentAction struct {
-	ID                            string            `json:"Id"`
-	Name                          string            `json:"Name"`
-	ActionType                    string            `json:"ActionType"`
-	IsDisabled                    bool              `json:"IsDisabled"`
-	CanBeUsedForProjectVersioning bool              `json:"CanBeUsedForProjectVersioning"`
-	Environments                  []string          `json:"Environments"`
-	ExcludedEnvironments          []string          `json:"ExcludedEnvironments"`
-	Channels                      []string          `json:"Channels"`
-	TenantTags                    []string          `json:"TenantTags"`
-	Properties                    map[string]string `json:"Properties"`     // TODO: refactor to use the PropertyValueResource for handling sensitive values - https://blog.gopheracademy.com/advent-2016/advanced-encoding-decoding/
-	LastModifiedOn                string            `json:"LastModifiedOn"` // datetime
-	LastModifiedBy                string            `json:"LastModifiedBy"`
-	Links                         Links             `json:"Links"` // may be wrong
+	ID                            string             `json:"Id,omitempty"`
+	Name                          string             `json:"Name"`
+	ActionType                    string             `json:"ActionType"`
+	IsDisabled                    bool               `json:"IsDisabled"`
+	IsRequired                    bool               `json:"IsRequired"`
+	WorkerPoolId                  string             `json:"WorkerPoolId,omitempty"`
+	CanBeUsedForProjectVersioning bool               `json:"CanBeUsedForProjectVersioning"`
+	Environments                  []string           `json:"Environments,omitempty"`
+	ExcludedEnvironments          []string           `json:"ExcludedEnvironments,omitempty"`
+	Channels                      []string           `json:"Channels,omitempty"`
+	TenantTags                    []string           `json:"TenantTags,omitempty"`
+	Properties                    map[string]string  `json:"Properties"` // TODO: refactor to use the PropertyValueResource for handling sensitive values - https://blog.gopheracademy.com/advent-2016/advanced-encoding-decoding/
+	Packages                      []PackageReference `json:"Packages,omitempty"`
 }
+
+
+type DeploymentStepPackageRequirement string
+
+const (
+	DeploymentStepPackageRequirement_LetOctopusDecide = DeploymentStepPackageRequirement("LetOctopusDecide")
+	DeploymentStepPackageRequirement_BeforePackageAcquisition = DeploymentStepPackageRequirement("BeforePackageAcquisition")
+	DeploymentStepPackageRequirement_AfterPackageAcquisition = DeploymentStepPackageRequirement("AfterPackageAcquisition")
+)
+
+type DeploymentStepCondition string
+
+const (
+	DeploymentStepCondition_Success = DeploymentStepCondition("Success")
+	DeploymentStepCondition_Failure = DeploymentStepCondition("Failure")
+	DeploymentStepCondition_Always = DeploymentStepCondition("Always")
+	DeploymentStepCondition_Variable = DeploymentStepCondition("Variable")
+)
+
+type DeploymentStepStartTrigger string
+
+const (
+	DeploymentStepStartTrigger_StartAfterPrevious = DeploymentStepStartTrigger("StartAfterPrevious")
+	DeploymentStepStartTrigger_StartWithPrevious = DeploymentStepStartTrigger("StartWithPrevious")
+)
+
+type PackageReference struct {
+	ID                  string            `json:"Id,omitempty"`
+	Name                string            `json:"Name,omitempty"`
+	PackageId           string            `json:"PackageId,omitempty"`
+	FeedId              string            `json:"FeedId"`
+	AcquisitionLocation string            `json:"AcquisitionLocation"` // This can be an expression
+	Properties          map[string]string `json:"Properties"`
+}
+
+const (
+	PackageAcquisitionLocation_Server = "Server"
+	PackageAcquisitionLocation_ExecutionTarget = "ExecutionTarget"
+	PackageAcquisitionLocation_NotAcquired = "NotAcquired"
+)
+
 
 func (d *DeploymentProcess) Validate() error {
 	validate := validator.New()


### PR DESCRIPTION
Allows the configuration of any kind of step configuration in Octopus as long as you know the magic incantations (or copy from the JSON).

I wanted to put the new files into a folder, which I understand is a "module". However I had trouble referencing back to the stuff in `util` as that had the same package name as the client library.

I'm going to build on this and implement a specific action type as an example.
