### PR TITLE
Some specific deployment actions

### DIFF
--- a/octopusdeploy/deploy_package.go
+++ b/octopusdeploy/deploy_package.go
@@ -7,7 +7,7 @@ import (
 
 func getDeployPackageAction() *schema.Schema {
 	actionSchema, element := getCommonDeploymentActionSchema()
-	addPrimaryPackageSchema(element)
+	addPrimaryPackageSchema(element, true)
 	//addCustomInstallationDirectoryFeature(element)
 	//addIisWebSiteAndApplicationPoolFeature(element)
 	addWindowsServiceFeature(element)
@@ -22,7 +22,8 @@ func getDeployPackageAction() *schema.Schema {
 }
 
 func buildDeployPackageActionResource(tfAction map[string]interface{}) octopusdeploy.DeploymentAction {
-	resource := buildDeploymentActionResource(tfAction)
-	// TODO
-	return resource
+	action := buildDeploymentActionResource(tfAction)
+	action.ActionType = "Octopus.TentaclePackage"
+	addWindowsServiceFeatureToActionResource(tfAction, action)
+	return action
 }

--- a/octopusdeploy/deploy_package.go
+++ b/octopusdeploy/deploy_package.go
@@ -1,0 +1,28 @@
+package octopusdeploy
+
+import (
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func getDeployPackageAction() *schema.Schema {
+	actionSchema, element := getCommonDeploymentActionSchema()
+	addPrimaryPackageSchema(element)
+	//addCustomInstallationDirectoryFeature(element)
+	//addIisWebSiteAndApplicationPoolFeature(element)
+	addWindowsServiceFeature(element)
+	//addCustomDeploymentScriptsFeature(element)
+	//addJsonConfigurationVariablesFeature(element)
+	//addConfigurationVariablesFeature(element)
+	//addConfigurationTransformsFeature(element)
+	//addSubstituteVariablesInFilesFeature(element)
+	//addIis6HomeDirectoryFeature(element)
+	//addRedGateDatabaseDeploymentFeature(element)
+	return actionSchema
+}
+
+func buildDeployPackageActionResource(tfAction map[string]interface{}) octopusdeploy.DeploymentAction {
+	resource := buildDeploymentActionResource(tfAction)
+	// TODO
+	return resource
+}

--- a/octopusdeploy/deploy_windows_service_action.go
+++ b/octopusdeploy/deploy_windows_service_action.go
@@ -1,0 +1,105 @@
+package octopusdeploy
+
+import (
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func getDeployWindowsServiceActionSchema() *schema.Schema {
+	actionSchema, element := getCommonDeploymentActionSchema()
+	addPrimaryPackageSchema(element)
+	addDeployWindowsServiceSchema(element)
+	//addCustomInstallationDirectoryFeature(element)
+	//addCustomDeploymentScriptsFeature(element)
+	//addJsonConfigurationVariablesFeature(element)
+	//addConfigurationVariablesFeature(element)
+	//addConfigurationTransformsFeature(element)
+	//addSubstituteVariablesInFilesFeature(element)
+	return actionSchema
+}
+
+func addWindowsServiceFeature(parent *schema.Resource) {
+	element := &schema.Resource{}
+	addDeployWindowsServiceSchema(element)
+	parent.Schema["windows_service"] = &schema.Schema{
+		Description: "Deploy a windows service feature",
+		Type:        schema.TypeSet,
+		Optional:    true,
+		MaxItems:    1,
+		Elem:        element,
+	}
+}
+
+func addDeployWindowsServiceSchema(element *schema.Resource) {
+	element.Schema["service_name"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "The name of the service",
+		Required:    true,
+	}
+	element.Schema["display_name"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "The display name of the service (optional)",
+		Optional:    true,
+	}
+	element.Schema["description"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "User-friendly description of the service (optional)",
+		Optional:    true,
+	}
+	element.Schema["executable_path"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "The path to the executable relative to the package installation directory",
+		Required:    true,
+	}
+	element.Schema["arguments"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "The command line arguments that will be passed to the service when it starts",
+		Optional:    true,
+	}
+	element.Schema["service_account"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "Which built-in account will the service run under",
+		Required:    true,
+	}
+	element.Schema["custom_account_name"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "The Windows/domain account of the custom user that the service will run under",
+		Optional:    true,
+	}
+	element.Schema["custom_account_password"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "The password for the custom account",
+		Optional:    true,
+	}
+	element.Schema["start_mode"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "When will the service start. Can be Automatic, Automatic (delayed), Manual, Unchanged or an expression",
+		Required:    true,
+	}
+	element.Schema["dependencies"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "Any dependencies that the service has. Separate the names using forward slashes (/).",
+		Optional:    true,
+	}
+}
+
+
+func buildDeployWindowsServiceActionResource(tfAction map[string]interface{}) octopusdeploy.DeploymentAction {
+	resource := buildDeploymentActionResource(tfAction)
+	addWindowsServiceToResource(tfAction, resource)
+	return resource
+}
+
+
+func addWindowsServiceFeatureToResource(tfAction map[string]interface{}, resource octopusdeploy.DeploymentAction) {
+	if windowsServiceList, ok := tfAction["windows_service"]; ok {
+		tfWindowsService := windowsServiceList.(*schema.Set).List()
+		if(len(tfWindowsService) > 0) {
+			addWindowsServiceToResource(tfWindowsService[0].(map[string]interface{}), resource)
+		}
+	}
+}
+
+func addWindowsServiceToResource(tfAction map[string]interface{}, resource octopusdeploy.DeploymentAction) {
+	// TODO
+}

--- a/octopusdeploy/deploy_windows_service_action_test.go
+++ b/octopusdeploy/deploy_windows_service_action_test.go
@@ -1,0 +1,157 @@
+package octopusdeploy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOctopusDeployDeployWindowsServiceAction(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckOctopusDeployDeploymentProcessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeployWindowsServiceAction(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeployWindowsServiceActionOrFeature("Octopus.WindowsService"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOctopusDeployWindowsServiceFeature(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckOctopusDeployDeploymentProcessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWindowsServiceFeature(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeployWindowsServiceActionOrFeature("Octopus.TentaclePackage"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDeployWindowsServiceAction() string {
+	return testAccBuildTestActionTerraform(`
+		deploy_windows_service_action {
+			name = "Test"
+
+			primary_package {
+				package_id = "MyPackage"
+			}
+
+			service_name = "MyService"
+			display_name = "My Service"
+			description = "Do stuff"
+			executable_path = "MyService.exe"
+			arguments = "-arg"
+			service_account = "_CUSTOM"
+			custom_account_name = "User"
+			custom_account_password = "Password"
+			start_mode = "manual"
+			dependencies = "OtherService"
+		}
+	`)
+}
+
+func testAccWindowsServiceFeature() string {
+	return testAccBuildTestActionTerraform(`
+		deploy_package_action {
+			name = "Test"
+
+			primary_package {
+				package_id = "MyPackage"
+			}
+
+			windows_service {
+				service_name = "MyService"
+				display_name = "My Service"
+				description = "Do stuff"
+				executable_path = "MyService.exe"
+				arguments = "-arg"
+				service_account = "_CUSTOM"
+				custom_account_name = "User"
+				custom_account_password = "Password"
+				start_mode = "manual"
+				dependencies = "OtherService"
+			}
+		}
+	`)
+}
+
+func testAccCheckDeployWindowsServiceActionOrFeature(expectedActionType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*octopusdeploy.Client)
+
+		process, err := getDeploymentProcess(s, client);
+		if err != nil {
+			return err
+		}
+
+		action := process.Steps[0].Actions[0]
+
+		if action.ActionType != expectedActionType {
+			return fmt.Errorf("Action type is incorrect: %s, expected: %s", action.ActionType, expectedActionType)
+		}
+
+		if(len(action.Packages) == 0) {
+			return fmt.Errorf("No package")
+		}
+
+		if action.Properties["Octopus.Action.WindowsService.CreateOrUpdateService"] != "True" {
+			return fmt.Errorf("Windows Service feature is not enabled")
+		}
+
+		if action.Properties["Octopus.Action.WindowsService.ServiceName"] != "MyService" {
+			return fmt.Errorf("Service Name is incorrect: %s", action.Properties["Octopus.Action.WindowsService.ServiceName"])
+		}
+
+		if action.Properties["Octopus.Action.WindowsService.DisplayName"] != "My Service" {
+			return fmt.Errorf("Display Name is incorrect: %s", action.Properties["Octopus.Action.WindowsService.DisplayName"])
+		}
+
+		if action.Properties["Octopus.Action.WindowsService.Description"] != "Do stuff" {
+			return fmt.Errorf("Description is incorrect: %s", action.Properties["Octopus.Action.WindowsService.Description"])
+		}
+
+		if action.Properties["Octopus.Action.WindowsService.ExecutablePath"] != "MyService.exe" {
+			return fmt.Errorf("Executable Path is incorrect: %s", action.Properties["Octopus.Action.WindowsService.ExecutablePath"])
+		}
+
+		if action.Properties["Octopus.Action.WindowsService.Arguments"] != "-arg" {
+			return fmt.Errorf("Arguments is incorrect: %s", action.Properties["Octopus.Action.WindowsService.Arguments"])
+		}
+
+		if action.Properties["Octopus.Action.WindowsService.ServiceAccount"] != "_CUSTOM" {
+			return fmt.Errorf("Service Account is incorrect: %s", action.Properties["Octopus.Action.WindowsService.ServiceAccount"])
+		}
+
+		if action.Properties["Octopus.Action.WindowsService.CustomAccountName"] != "User" {
+			return fmt.Errorf("Custom Account Name is incorrect: %s", action.Properties["Octopus.Action.WindowsService.CustomAccountName"])
+		}
+
+		if action.Properties["Octopus.Action.WindowsService.CustomAccountPassword"] != "Password" {
+			return fmt.Errorf("Custom Account Password is incorrect: %s", action.Properties["Octopus.Action.WindowsService.CustomAccountPassword"])
+		}
+
+		if action.Properties["Octopus.Action.WindowsService.StartMode"] != "manual" {
+			return fmt.Errorf("Start Mode is incorrect: %s", action.Properties["Octopus.Action.WindowsService.StartMode"])
+		}
+
+		if action.Properties["Octopus.Action.WindowsService.Dependencies"] != "OtherService" {
+			return fmt.Errorf("Dependencies is incorrect: %s", action.Properties["Octopus.Action.WindowsService.Dependencies"])
+		}
+
+		return nil;
+	}
+}

--- a/octopusdeploy/deployment_action.go
+++ b/octopusdeploy/deployment_action.go
@@ -106,7 +106,6 @@ func addWorkerPoolSchema(element *schema.Resource) {
 func buildDeploymentActionResource(tfAction map[string]interface{}) octopusdeploy.DeploymentAction {
 	action := octopusdeploy.DeploymentAction{
 		Name:                 tfAction["name"].(string),
-		ActionType:           tfAction["action_type"].(string),
 		IsDisabled:           tfAction["disabled"].(bool),
 		IsRequired:           tfAction["required"].(bool),
 		Environments:         getSliceFromTerraformTypeList(tfAction["environments"]),
@@ -114,6 +113,11 @@ func buildDeploymentActionResource(tfAction map[string]interface{}) octopusdeplo
 		Channels:             getSliceFromTerraformTypeList(tfAction["channels"]),
 		TenantTags:           getSliceFromTerraformTypeList(tfAction["tenant_tags"]),
 		Properties:           map[string]string{},
+	}
+
+	actionType := tfAction["action_type"]
+	if actionType != nil {
+		action.ActionType = actionType.(string)
 	}
 
 	// Even though not all actions have these properties, we'll keep them here.

--- a/octopusdeploy/deployment_action.go
+++ b/octopusdeploy/deployment_action.go
@@ -15,7 +15,7 @@ func getDeploymentActionSchema() *schema.Schema {
 		Required:    true,
 	}
 	addWorkerPoolSchema(element)
-	addPackagesSchema(element)
+	addPackagesSchema(element, false)
 
 	return actionSchema;
 }

--- a/octopusdeploy/deployment_action.go
+++ b/octopusdeploy/deployment_action.go
@@ -7,81 +7,98 @@ import (
 )
 
 func getDeploymentActionSchema() *schema.Schema {
-	return &schema.Schema{
+	actionSchema, element := getCommonDeploymentActionSchema()
+	addExecutionLocationSchema(element);
+	element.Schema["action_type"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "The type of action",
+		Required:    true,
+	}
+	addWorkerPoolSchema(element)
+	addPackagesSchema(element)
+
+	return actionSchema;
+}
+
+func getCommonDeploymentActionSchema() (*schema.Schema, *schema.Resource) {
+	element := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The name of the action",
+				Required:    true,
+			},
+			"disabled": {
+				Type:        schema.TypeBool,
+				Description: "Whether this step is disabled",
+				Optional:    true,
+				Default:     false,
+			},
+			"required": {
+				Type:        schema.TypeBool,
+				Description: "Whether this step is required and cannot be skipped",
+				Optional:    true,
+				Default:     false,
+			},
+			"environments": {
+				Description: "The environments that this step will run in",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"excluded_environments": {
+				Description: "The environments that this step will be skipped in",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"channels": {
+				Description: "The channels that this step applies to",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"tenant_tags": {
+				Description: "The tags for the tenants that this step applies to",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"property": getPropertySchema(),
+		},
+	}
+
+	actionSchema := &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"name": {
-					Type:        schema.TypeString,
-					Description: "The name of the action",
-					Required:    true,
-				},
-				"action_type": {
-					Type:        schema.TypeString,
-					Description: "The type of action",
-					Required:    true,
-				},
-				"run_on_server": {
-					Type:        schema.TypeBool,
-					Description: "Whether this step runs on a worker or on the target",
-					Optional:    true,
-					Default: 	 false,
-				},
-				"disabled": {
-					Type:        schema.TypeBool,
-					Description: "Whether this step is disabled",
-					Optional:    true,
-					Default: 	 false,
-				},
-				"required": {
-					Type:        schema.TypeBool,
-					Description: "Whether this step is required and cannot be skipped",
-					Optional:    true,
-					Default: 	 false,
-				},
-				"worker_pool_id": {
-					Type:        schema.TypeString,
-					Description: "Which worker pool to run on",
-					Optional:    true,
-				},
-				"environments": &schema.Schema{
-					Description: "The environments that this step will run in",
-					Type:        schema.TypeList,
-					Optional:    true,
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
-					},
-				},
-				"excluded_environments": &schema.Schema{
-					Description: "The environments that this still will be skipped in",
-					Type:        schema.TypeList,
-					Optional:    true,
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
-					},
-				},
-				"channels": &schema.Schema{
-					Description: "The channels that this step applies to",
-					Type:        schema.TypeList,
-					Optional:    true,
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
-					},
-				},
-				"tenant_tags": &schema.Schema{
-					Description: "The tags for the tenants that this step applies to",
-					Type:        schema.TypeList,
-					Optional:    true,
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
-					},
-				},
-				"property": getPropertySchema(),
-				"primary_package": getPrimaryPackageSchema(),
-				"package": getPackageSchema(),
-			},
-		},
+		Elem:     element,
+	}
+
+	return actionSchema, element
+}
+
+func addExecutionLocationSchema(element *schema.Resource) {
+	element.Schema["run_on_server"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Description: "Whether this step runs on a worker or on the target",
+		Optional:    true,
+		Default:     false,
+	}
+}
+
+func addWorkerPoolSchema(element *schema.Resource) {
+	element.Schema["worker_pool_id"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "Which worker pool to run on",
+		Optional:    true,
 	}
 }
 
@@ -99,6 +116,8 @@ func buildDeploymentActionResource(tfAction map[string]interface{}) octopusdeplo
 		Properties:           map[string]string{},
 	}
 
+	// Even though not all actions have these properties, we'll keep them here.
+	// They will just be ignored if the action doesn't have it
 	runOnServer := tfAction["run_on_server"]
 	if runOnServer != nil {
 		action.Properties["Octopus.Action.RunOnServer"] = strconv.FormatBool(runOnServer.(bool))

--- a/octopusdeploy/deployment_process_test.go
+++ b/octopusdeploy/deployment_process_test.go
@@ -98,21 +98,21 @@ func testAccDeploymentProcessBasic() string {
 				}
 			}
 
- step {
-        name = "Step2"
-        start_trigger = "StartWithPrevious"
-
-        action {
-            name = "Step2"
-            action_type = "Octopus.Script"
-            run_on_server = true
-
-            property {
-                key = "Octopus.Action.Script.ScriptBody"
-                value = "Write-Host 'hi'"
-            }
-        }
-    }
+ 			step {
+ 			       name = "Step2"
+ 			       start_trigger = "StartWithPrevious"
+			
+ 			       action {
+ 			           name = "Step2"
+ 			           action_type = "Octopus.Script"
+ 			           run_on_server = true
+			
+ 			           property {
+ 			               key = "Octopus.Action.Script.ScriptBody"
+ 			               value = "Write-Host 'hi'"
+ 			           }
+ 			       }
+			} 
 		}
 		`
 }
@@ -141,7 +141,7 @@ func testAccCheckOctopusDeployDeploymentProcess() resource.TestCheckFunc {
 			return err
 		}
 
-		expectedNumberOfSteps := 1
+		expectedNumberOfSteps := 2
 		numberOfSteps := len(process.Steps)
 		if numberOfSteps != expectedNumberOfSteps {
 			return fmt.Errorf("Deployment process has %d steps instead of the expected %d", numberOfSteps, expectedNumberOfSteps)

--- a/octopusdeploy/deployment_process_test.go
+++ b/octopusdeploy/deployment_process_test.go
@@ -117,6 +117,35 @@ func testAccDeploymentProcessBasic() string {
 		`
 }
 
+func testAccBuildTestActionTerraform(action string) string {
+	return fmt.Sprintf( `
+		resource "octopusdeploy_lifecycle" "test" {
+			name = "Test Lifecycle"
+		}
+
+		resource "octopusdeploy_project_group" "test" {
+			name = "Test Group"
+		}
+
+		resource "octopusdeploy_project" "test" {
+			name             = "Test Project"
+			lifecycle_id     = "${octopusdeploy_lifecycle.test.id}"
+			project_group_id = "${octopusdeploy_project_group.test.id}"
+		}
+
+		resource "octopusdeploy_deployment_process" "test" {
+			project_id = "${octopusdeploy_project.test.id}"
+
+			step {
+				name = "Test"
+				target_roles = ["WebServer"]
+
+				%s
+			}
+		}
+		`, action)
+}
+
 func testAccCheckOctopusDeployDeploymentProcessDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*octopusdeploy.Client)
 

--- a/octopusdeploy/deployment_step.go
+++ b/octopusdeploy/deployment_step.go
@@ -71,8 +71,8 @@ func getDeploymentStepSchema() *schema.Schema {
 				},
 				"action": getDeploymentActionSchema(),
 				"manual_intervention_action": getManualInterventionActionSchema(),
-				"deploy_package_action": getDeploymentActionSchema(),
-				"deploy_windows_service_action": getDeploymentActionSchema(),
+				"deploy_package_action": getDeployPackageAction(),
+				"deploy_windows_service_action": getDeployWindowsServiceActionSchema(),
 			},
 		},
 	}

--- a/octopusdeploy/deployment_step.go
+++ b/octopusdeploy/deployment_step.go
@@ -70,6 +70,9 @@ func getDeploymentStepSchema() *schema.Schema {
 					Optional:    true,
 				},
 				"action": getDeploymentActionSchema(),
+				"manual_intervention_action": getManualInterventionActionSchema(),
+				"deploy_package_action": getDeploymentActionSchema(),
+				"deploy_windows_service_action": getDeploymentActionSchema(),
 			},
 		},
 	}
@@ -102,6 +105,27 @@ func buildDeploymentStepResource(tfStep map[string]interface{}) octopusdeploy.De
 	if attr, ok := tfStep["action"]; ok {
 		for _, tfAction := range attr.([]interface {}) {
 			action := buildDeploymentActionResource(tfAction.(map[string]interface{}))
+			step.Actions = append(step.Actions, action)
+		}
+	}
+
+	if attr, ok := tfStep["manual_intervention_action"]; ok {
+		for _, tfAction := range attr.([]interface {}) {
+			action := buildManualInterventionActionResource(tfAction.(map[string]interface{}))
+			step.Actions = append(step.Actions, action)
+		}
+	}
+
+	if attr, ok := tfStep["deploy_package_action"]; ok {
+		for _, tfAction := range attr.([]interface {}) {
+			action := buildDeployPackageActionResource(tfAction.(map[string]interface{}))
+			step.Actions = append(step.Actions, action)
+		}
+	}
+
+	if attr, ok := tfStep["deploy_windows_service_action"]; ok {
+		for _, tfAction := range attr.([]interface {}) {
+			action := buildDeployWindowsServiceActionResource(tfAction.(map[string]interface{}))
 			step.Actions = append(step.Actions, action)
 		}
 	}

--- a/octopusdeploy/manual_intervention_action.go
+++ b/octopusdeploy/manual_intervention_action.go
@@ -25,6 +25,13 @@ func getManualInterventionActionSchema()  *schema.Schema {
 
 func buildManualInterventionActionResource(tfAction map[string]interface{}) octopusdeploy.DeploymentAction {
 	resource := buildDeploymentActionResource(tfAction)
-	// TODO
+	resource.ActionType = "Octopus.Manual"
+	resource.Properties["Octopus.Action.Manual.Instructions"] = tfAction["instructions"].(string);
+
+	responsibleTeams := tfAction["responsible_teams"]
+	if responsibleTeams != nil {
+		resource.Properties["Octopus.Action.Manual.ResponsibleTeamIds"] = responsibleTeams.(string)
+	}
+
 	return resource
 }

--- a/octopusdeploy/manual_intervention_action.go
+++ b/octopusdeploy/manual_intervention_action.go
@@ -1,0 +1,30 @@
+package octopusdeploy
+
+import (
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func getManualInterventionActionSchema()  *schema.Schema {
+	actionSchema, element := getCommonDeploymentActionSchema()
+
+	element.Schema["instructions"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "The instructions for the user to follow",
+		Required:    true,
+	}
+
+	element.Schema["responsible_teams"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "The teams responsible to resolve this step. If no teams are specified, all users who have permission to deploy the project can resolve it.",
+		Optional:    true,
+	}
+
+	return actionSchema;
+}
+
+func buildManualInterventionActionResource(tfAction map[string]interface{}) octopusdeploy.DeploymentAction {
+	resource := buildDeploymentActionResource(tfAction)
+	// TODO
+	return resource
+}

--- a/octopusdeploy/manual_intervention_action_test.go
+++ b/octopusdeploy/manual_intervention_action_test.go
@@ -1,0 +1,86 @@
+package octopusdeploy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOctopusDeployManualInterventionAction(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckOctopusDeployDeploymentProcessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccManualInterventionAction(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckManualInterventionAction(),
+				),
+			},
+		},
+	})
+}
+
+func testAccManualInterventionAction() string {
+	return `
+		resource "octopusdeploy_lifecycle" "test" {
+			name = "Test Lifecycle"
+		}
+
+		resource "octopusdeploy_project_group" "test" {
+			name = "Test Group"
+		}
+
+		resource "octopusdeploy_project" "test" {
+			name             = "Test Project"
+			lifecycle_id     = "${octopusdeploy_lifecycle.test.id}"
+			project_group_id = "${octopusdeploy_project_group.test.id}"
+		}
+
+		resource "octopusdeploy_deployment_process" "test" {
+			project_id = "${octopusdeploy_project.test.id}"
+
+			step {
+				name = "Test"
+
+				manual_intervention_action {
+					name = "Test"
+					instructions = "Approve Me"
+					responsible_teams = "A Team"
+				}
+			}
+		}
+		`
+}
+
+func testAccCheckManualInterventionAction() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*octopusdeploy.Client)
+
+		process, err := getDeploymentProcess(s, client);
+		if err != nil {
+			return err
+		}
+
+		action := process.Steps[0].Actions[0]
+
+		if action.ActionType != "Octopus.Manual" {
+			return fmt.Errorf("Action type is incorrect: %s", action.ActionType)
+		}
+
+		if action.Properties["Octopus.Action.Manual.Instructions"] != "Approve Me" {
+			return fmt.Errorf("Instructions is incorrect: %s", action.Properties["Octopus.Action.Manual.Instructions"])
+		}
+
+		if action.Properties["Octopus.Action.Manual.ResponsibleTeamIds"] != "A Team" {
+			return fmt.Errorf("ResponsibleTeamIds is incorrect: %s", action.Properties["Octopus.Action.Manual.ResponsibleTeamIds"])
+		}
+
+
+		return nil;
+	}
+}

--- a/octopusdeploy/manual_intervention_action_test.go
+++ b/octopusdeploy/manual_intervention_action_test.go
@@ -26,35 +26,13 @@ func TestAccOctopusDeployManualInterventionAction(t *testing.T) {
 }
 
 func testAccManualInterventionAction() string {
-	return `
-		resource "octopusdeploy_lifecycle" "test" {
-			name = "Test Lifecycle"
+	return testAccBuildTestActionTerraform(`
+		manual_intervention_action {
+			name = "Test"
+			instructions = "Approve Me"
+			responsible_teams = "A Team"
 		}
-
-		resource "octopusdeploy_project_group" "test" {
-			name = "Test Group"
-		}
-
-		resource "octopusdeploy_project" "test" {
-			name             = "Test Project"
-			lifecycle_id     = "${octopusdeploy_lifecycle.test.id}"
-			project_group_id = "${octopusdeploy_project_group.test.id}"
-		}
-
-		resource "octopusdeploy_deployment_process" "test" {
-			project_id = "${octopusdeploy_project.test.id}"
-
-			step {
-				name = "Test"
-
-				manual_intervention_action {
-					name = "Test"
-					instructions = "Approve Me"
-					responsible_teams = "A Team"
-				}
-			}
-		}
-		`
+	`)
 }
 
 func testAccCheckManualInterventionAction() resource.TestCheckFunc {

--- a/octopusdeploy/package_reference.go
+++ b/octopusdeploy/package_reference.go
@@ -5,6 +5,28 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+func addPrimaryPackageSchema(element *schema.Resource)  {
+	element.Schema["primary_package"] = getPrimaryPackageSchema();
+}
+
+func addPackagesSchema(element *schema.Resource)  {
+	addPrimaryPackageSchema(element)
+
+	element.Schema["package"] = getPrimaryPackageSchema();
+
+	packageElementSchema := element.Schema["package"].Elem.(*schema.Resource).Schema
+	packageElementSchema["name"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "The name of the package",
+		Required:    true,
+	}
+	packageElementSchema["extract_during_deployment"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "Whether to extract the package during deployment",
+		Optional:    true,
+		Default:     "true",
+	}
+}
 
 func getPrimaryPackageSchema() *schema.Schema {
 	return &schema.Schema{
@@ -37,22 +59,6 @@ func getPrimaryPackageSchema() *schema.Schema {
 	}
 }
 
-func getPackageSchema() *schema.Schema {
-	s := getPrimaryPackageSchema();
-	elementSchema := s.Elem.(*schema.Resource).Schema
-	elementSchema["name"] = &schema.Schema{
-		Type:        schema.TypeString,
-		Description: "The name of the package",
-		Required:    true,
-	}
-	elementSchema["extract_during_deployment"] = &schema.Schema{
-		Type:        schema.TypeString,
-		Description: "Whether to extract the package during deployment",
-		Optional:    true,
-		Default:     "true",
-	}
-	return s
-}
 
 func buildPackageReferenceResource(tfPkg map[string]interface{}) octopusdeploy.PackageReference {
 	pkg := octopusdeploy.PackageReference{

--- a/octopusdeploy/package_reference.go
+++ b/octopusdeploy/package_reference.go
@@ -5,14 +5,14 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-func addPrimaryPackageSchema(element *schema.Resource)  {
-	element.Schema["primary_package"] = getPrimaryPackageSchema();
+func addPrimaryPackageSchema(element *schema.Resource, required bool)  {
+	element.Schema["primary_package"] = getPackageSchema(required);
 }
 
-func addPackagesSchema(element *schema.Resource)  {
-	addPrimaryPackageSchema(element)
+func addPackagesSchema(element *schema.Resource, primaryIsRequired bool)  {
+	addPrimaryPackageSchema(element, primaryIsRequired)
 
-	element.Schema["package"] = getPrimaryPackageSchema();
+	element.Schema["package"] = getPackageSchema(false);
 
 	packageElementSchema := element.Schema["package"].Elem.(*schema.Resource).Schema
 	packageElementSchema["name"] = &schema.Schema{
@@ -28,11 +28,12 @@ func addPackagesSchema(element *schema.Resource)  {
 	}
 }
 
-func getPrimaryPackageSchema() *schema.Schema {
+func getPackageSchema(required bool) *schema.Schema {
 	return &schema.Schema{
 		Description: "The primary package for the action",
 		Type:        schema.TypeSet,
-		Optional:    true,
+		Required:    required,
+		Optional:    !required,
 		MaxItems:	 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Manual Intervention, Deploy Package and Windows Service actions. Also the Windows Service Feature for deploy package.

I've put in commented out placeholders for the other kinds of features for deploy package.

Many of the steps in octopus are special cases of either the Deploy Package step or Script step. For the former the main difference is that certain features are on by default and can't be turned off. For the latter it's mostly about which account and tools get loaded.