### PR TITLE
Adds importers to variables, environments and machines

### DIFF
--- a/octopusdeploy/resource_environment.go
+++ b/octopusdeploy/resource_environment.go
@@ -13,6 +13,9 @@ func resourceEnvironment() *schema.Resource {
 		Read:   resourceEnvironmentRead,
 		Update: resourceEnvironmentUpdate,
 		Delete: resourceEnvironmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/octopusdeploy/resource_machine.go
+++ b/octopusdeploy/resource_machine.go
@@ -13,6 +13,9 @@ func resourceMachine() *schema.Resource {
 		Read:   resourceMachineRead,
 		Update: resourceMachineUpdate,
 		Delete: resourceMachineDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/octopusdeploy/resource_variable.go
+++ b/octopusdeploy/resource_variable.go
@@ -2,6 +2,7 @@ package octopusdeploy
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -13,6 +14,9 @@ func resourceVariable() *schema.Resource {
 		Read:   resourceVariableRead,
 		Update: resourceVariableUpdate,
 		Delete: resourceVariableDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceVariableImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"project_id": &schema.Schema{
@@ -75,6 +79,18 @@ func resourceVariable() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceVariableImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	importStrings := strings.Split(d.Id(), ":")
+	if len(importStrings) != 2 {
+		return nil, fmt.Errorf("octopusdeploy_variable import must be in the form of ProjectID:VariableID (e.g. Projects-62:0906031f-68ba-4a15-afaa-657c1564e07b")
+	}
+
+	d.Set("project_id", importStrings[0])
+	d.SetId(importStrings[1])
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceVariableRead(d *schema.ResourceData, m interface{}) error {


### PR DESCRIPTION
In response to #23 this adds importers to Environments, Machines and Variables.

Environments and Machines are really straight forward and just take the resource GUID.

Variables need a Project GUID and a resource GUID. I don't know what the correct Terraform formatting for that is, so I designed it as `ProjectID:VariableID`. For example:

```
terraform import octopusdeploy_variable.testvar Projects-62:0906031f-68ba-4a15-afaa-657c1564e07ba
```
