### PR TITLE
Switch to hosted octo integration tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,27 +8,23 @@ skip_commits:
 image: Visual Studio 2017
 build: off
 clone_folder: c:\gopath\src\github.com\MattHodge\terraform-provider-octopusdeploy
-services:
-  - mssql2017
 
 environment:
   GOPATH: c:\gopath
-  TEST_OCTOPUS_USERNAME: Administrator
-  TEST_OCTOPUS_PASSWORD: Password1! # This password is for the Octopus Deploy server spun up in Appveyor.
   GO111MODULE: on # Enable Go Module Support
+  # Settings for Octopus Deploy cloud for integration testing
+  OCTOPUS_URL:
+    secure: jP+YI6rOk5iO1YYgTczw5GA5i2QrBHcfhxw9dRd0zUo=
+  OCTOPUS_APIKEY:
+    secure: rhHMBdDw0HiZtu1w5XmrNHXB8G37o827aHx0E+ufhSY=
 
 install:
-  - ps: choco install golang --version 1.11.4
+  - ps: choco install golang --version 1.11.4 --no-progress --confirm
   - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
   - go version
 
 before_test:
-  # Octopus install needs to occur here as mssql doesn't start before the install step
-  - ps: >-
-      . ".\integration\appveyor_scripts\functions\Install-OctopusDeployInAppveyor.ps1" ;
-      . ".\integration\appveyor_scripts\functions\Start-ProcessAdvanced.ps1" ;
-      Install-OctopusDeployInAppveyor -OctopusAdministartorUser $env:TEST_OCTOPUS_USERNAME -OctopusAdministartorPassword $env:TEST_OCTOPUS_PASSWORD
-  - ps: Invoke-Expression ".\integration\appveyor_scripts\start_go_integration_tests.ps1"
+  - ps:  Invoke-Expression ".\integration\appveyor_scripts\start_integration_tests.ps1"
 
 after_test:
   # Build Binaries
@@ -44,7 +40,8 @@ deploy:
   draft: false
   prerelease: true
   on:
-    branch: master                 # release from master branch only
+    # release from master branch only
+    branch: master
 
 # # Uncomment to debug the build
 # on_finish:

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dghubble/sling v1.1.0 h1:DLu20Bq2qsB9cI5Hldaxj+TMPEaPpPE8IR2kvD22Atg=
 github.com/dghubble/sling v1.1.0/go.mod h1:ZcPRuLm0qrcULW2gOrjXrAWgf76sahqSyxXyVOvkunE=
@@ -72,6 +73,7 @@ github.com/hashicorp/hcl2 v0.0.0-20181001210626-3e4b7e0eb20e h1:46y3vckATUnyhAjm
 github.com/hashicorp/hcl2 v0.0.0-20181001210626-3e4b7e0eb20e/go.mod h1:hrRmgPTdXWuNLpHcv7cRXL+ofoFsY76vDylTzH8eu3E=
 github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250 h1:fooK5IvDL/KIsi4LxF/JH68nVdrBSiGNPhS2JAQjtjo=
 github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250/go.mod h1:KHvg/R2/dPtaePb16oW4qIyzkMxXOL38xjRN64adsts=
+github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform v0.11.8 h1:fxt+ihK6GZA8Qj2OSNW/j5hn8sE7pFMFS6/HTseTBJI=
 github.com/hashicorp/terraform v0.11.8/go.mod h1:uN1KUiT7Wdg61fPwsGXQwK3c8PmpIVZrt5Vcb1VrSoM=

--- a/integration/appveyor_scripts/start_integration_tests.ps1
+++ b/integration/appveyor_scripts/start_integration_tests.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Stop'
+
+# Load Functions
+$functionFolder = Get-ChildItem -Path (Join-Path -Path $PWD -ChildPath 'integration\appveyor_scripts\functions')
+foreach ($function in $functionFolder) { . $function.FullName }
+
+Start-ProcessAdvanced -FilePath 'go' -ArgumentList "test -v -timeout 120s ./octopusdeploy/..." -EnvironmentKeyValues @{ TF_ACC = 1 } -Verbose

--- a/octopusdeploy/resource_project_deployment_target_trigger_test.go
+++ b/octopusdeploy/resource_project_deployment_target_trigger_test.go
@@ -80,10 +80,14 @@ func TestAccOctopusDeployDeploymentTargetTriggerUpdate(t *testing.T) {
 
 func testAccProjectDeploymentTargetTriggerResource(t *testing.T, triggerName, projectName string) string {
 	return fmt.Sprintf(`
+		resource "octopusdeploy_project_group" "foo" {
+			name = "Integration Test Project Group"
+		}
+
 		resource "octopusdeploy_project" "foo" {
 			lifecycle_id          = "Lifecycles-1"
 			name                  = "%s"
-			project_group_id      = "ProjectGroups-1"
+			project_group_id      = "${octopusdeploy_project_group.foo.id}"
 	  	}
 
 		resource "octopusdeploy_project_deployment_target_trigger" "foo" {
@@ -104,10 +108,14 @@ func testAccProjectDeploymentTargetTriggerResource(t *testing.T, triggerName, pr
 
 func testAccProjectDeploymentTargetTriggerResourceUpdated(t *testing.T, triggerName, projectName string) string {
 	return fmt.Sprintf(`
+		resource "octopusdeploy_project_group" "foo" {
+			name = "Integration Test Project Group"
+		}
+
 		resource "octopusdeploy_project" "foo" {
 			lifecycle_id          = "Lifecycles-1"
 			name                  = "%s"
-			project_group_id      = "ProjectGroups-1"
+			project_group_id      = "${octopusdeploy_project_group.foo.id}"
 	  	}
 
 		resource "octopusdeploy_project_deployment_target_trigger" "foo" {

--- a/octopusdeploy/resource_variable_test.go
+++ b/octopusdeploy/resource_variable_test.go
@@ -14,10 +14,8 @@ func TestAccOctopusDeployVariableBasic(t *testing.T) {
 	const tfVarName = "tf-var-1"
 	const tfVarDesc = "Terraform testing module variable"
 	const tfVarValue = "abcd-123456"
-
 	const projectName = "Funky Monkey Var Test"
 	const lifeCycleID = "Lifecycles-1"
-	const projectGroupID = "ProjectGroups-1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,7 +23,7 @@ func TestAccOctopusDeployVariableBasic(t *testing.T) {
 		CheckDestroy: testOctopusDeployVariableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testVariableBasic(projectName, lifeCycleID, projectGroupID, tfVarName, tfVarDesc, tfVarValue),
+				Config: testVariableBasic(projectName, lifeCycleID, tfVarName, tfVarDesc, tfVarValue),
 				Check: resource.ComposeTestCheckFunc(
 					testOctopusDeployVariableExists(tfVarPrefix),
 					resource.TestCheckResourceAttr(
@@ -40,12 +38,16 @@ func TestAccOctopusDeployVariableBasic(t *testing.T) {
 	})
 }
 
-func testVariableBasic(projectName, projectLifecycleID, projectGroupID, name, description, value string) string {
+func testVariableBasic(projectName, projectLifecycleID, name, description, value string) string {
 	config := fmt.Sprintf(`
+		resource "octopusdeploy_project_group" "foo" {
+			name = "Integration Test Project Group"
+		}
+
 		resource "octopusdeploy_project" "foo" {
 			name           = "%s"
 			lifecycle_id    = "%s"
-			project_group_id = "%s"
+			project_group_id = "${octopusdeploy_project_group.foo.id}"
 		}
 
 		resource "octopusdeploy_variable" "foovar" {
@@ -56,7 +58,7 @@ func testVariableBasic(projectName, projectLifecycleID, projectGroupID, name, de
 			value       = "%s"
 		}
 		`,
-		projectName, projectLifecycleID, projectGroupID, name, description, value,
+		projectName, projectLifecycleID, name, description, value,
 	)
 	fmt.Println(config)
 	return config


### PR DESCRIPTION
* Started using the hosted Octopus Deploy for Terraform Testing
* Upgraded to Go 1.11.4
* Fixed tests to create their own project group